### PR TITLE
changed the energy detector to use a proxy for the output

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/EnergyDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/EnergyDetectorPeripheral.java
@@ -21,13 +21,13 @@ public class EnergyDetectorPeripheral extends BasePeripheral {
 
     @LuaFunction(mainThread = true)
     public final int getTransferRateLimit() {
-        return tileEntity.maxTransferRate;
+        return tileEntity.storage.getMaxTransferRate();
     }
 
     @LuaFunction(mainThread = true)
     public final void setTransferRateLimit(long transferRate) {
         transferRate = Math.min(AdvancedPeripheralsConfig.energyDetectorMaxFlow, transferRate);
-        tileEntity.setMaxTransferRate((int) transferRate);
+        tileEntity.storage.setMaxTransferRate((int) transferRate);
     }
 
     @LuaFunction(mainThread = true)

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/AdvancedPeripheralsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/AdvancedPeripheralsConfig.java
@@ -42,8 +42,7 @@ public class AdvancedPeripheralsConfig {
             CHAT_BOX_COOLDOWN = builder.comment("Defines the chat box cooldown for message sending.").defineInRange("chatBoxCooldown", 10, 1, 100000);
             PLAYER_DET_MAX_RANGE = builder.comment("The max range of the player detector functions. " +
                     "If anyone use a higher range, the detector will use this max range").defineInRange("playerDetMaxRange", 2147483646, 0, 2147483646);
-            ENERGY_DETECTOR_MAX_FLOW = builder.comment("Defines the maximum energy flow of the energy detector. " +
-                    "The energy detector acts as an energy storage, do not increase this value too much.").defineInRange("energyDetectorMaxFlow", 64000, 1, Integer.MAX_VALUE);
+            ENERGY_DETECTOR_MAX_FLOW = builder.comment("Defines the maximum energy flow of the energy detector.").defineInRange("energyDetectorMaxFlow", Integer.MAX_VALUE, 1, Integer.MAX_VALUE);
 
             builder.pop();
 

--- a/src/main/java/de/srendi/advancedperipherals/common/util/EnergyStorageProxy.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/EnergyStorageProxy.java
@@ -1,0 +1,81 @@
+package de.srendi.advancedperipherals.common.util;
+
+import java.util.Optional;
+
+import de.srendi.advancedperipherals.common.blocks.tileentity.EnergyDetectorTileEntity;
+import net.minecraftforge.energy.IEnergyStorage;
+
+public class EnergyStorageProxy implements IEnergyStorage {
+
+    private EnergyDetectorTileEntity energyDetectorTE;
+    private int maxTransferRate;
+    private int transferedInThisTick = 0;
+
+    public EnergyStorageProxy(EnergyDetectorTileEntity energyDetectorTE, int maxTransferRate) {
+        this.energyDetectorTE = energyDetectorTE;
+        this.maxTransferRate = maxTransferRate;
+    }
+
+    @Override
+    public boolean canReceive() {
+        return true;
+    }
+
+    @Override
+    public int receiveEnergy(int maxReceive, boolean simulate) {
+        Optional<IEnergyStorage> out = energyDetectorTE.getOutputStorage();
+        return out.map(outStorage -> {
+            int transferred = outStorage.receiveEnergy(Math.min(maxReceive, maxTransferRate), simulate);
+            if (simulate) {
+                transferedInThisTick += transferred;
+                //transferedInThisTick = transferred;
+            }
+            return transferred;
+        }).orElse(0);
+    }
+
+    @Override
+    public int getEnergyStored() {
+        Optional<IEnergyStorage> out = energyDetectorTE.getOutputStorage();
+        return out.map(outStorage -> {
+            return outStorage.getEnergyStored();
+        }).orElse(0);
+    }
+
+    @Override
+    public int getMaxEnergyStored() {
+        Optional<IEnergyStorage> out = energyDetectorTE.getOutputStorage();
+        return out.map(outStorage -> {
+            return outStorage.getMaxEnergyStored();
+        }).orElse(0);
+    }
+
+    @Override
+    public boolean canExtract() {
+        return false;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate) {
+        return 0;
+    }
+
+    public void setMaxTransferRate(int rate) {
+        maxTransferRate = rate;
+    }
+
+    public int getMaxTransferRate() {
+        return maxTransferRate;
+    }
+
+    /**
+     * should be called on every tick
+     */
+    public void resetTransferedInThisTick() {
+        transferedInThisTick = 0;
+    }
+
+    public int getTransferedInThisTick() {
+        return transferedInThisTick;
+    }
+}


### PR DESCRIPTION
this should fix #52, the energy detector receives and forwards the energy now completely passiv instead of actively draining energy from the input.


## notes
I still get in lua sometimes miss matching results from EnergyDetector.getTransferRate() when using Mekanism universal cables, but this might be a Mekanism bug since it works now as expected when using other cables.
