### PR TITLE
fix: InventoryManager removeItemFromPlayer NullPointer if inv is missing

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
@@ -55,7 +55,7 @@ public class InventoryManagerPeripheral extends BasePeripheral {
         IItemHandler inventoryFrom = targetEntity != null ? targetEntity
                 .getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, direction).resolve().orElse(null) : null;
         PlayerInventory inventoryTo = getOwnerPlayer().inventory;
-        if (inventoryFrom == null) {
+        if (inventoryFrom == null || inventoryTo == null) {
             AdvancedPeripherals.debug("Debug2");
             return 0;
         }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
@@ -55,8 +55,9 @@ public class InventoryManagerPeripheral extends BasePeripheral {
         IItemHandler inventoryFrom = targetEntity != null ? targetEntity
                 .getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, direction).resolve().orElse(null) : null;
         PlayerInventory inventoryTo = getOwnerPlayer().inventory;
-        if (inventoryFrom == null || inventoryTo == null) {
-            AdvancedPeripherals.debug("Debug2");
+
+        // inventoryFrom is checked via ensurePlayerLinked()
+        if (inventoryTo == null) {
             return 0;
         }
 


### PR DESCRIPTION
closes Seniorendi/AdvancedPeripherals#87

Just a quick null-check addition.