### PR TITLE
[#82] Fix null pointer on chat events

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/events/Events.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/events/Events.java
@@ -2,6 +2,7 @@ package de.srendi.advancedperipherals.common.events;
 
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.turtle.blocks.TileTurtle;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
 import de.srendi.advancedperipherals.common.addons.computercraft.turtles.TurtleChatBox;
@@ -56,12 +57,17 @@ public class Events {
             if (tileEntity instanceof TileTurtle) { //Events for turtles
                 TileTurtle tileTurtle = (TileTurtle) tileEntity;
                 if (tileTurtle.getUpgrade(TurtleSide.RIGHT) instanceof TurtleChatBox || tileTurtle.getUpgrade(TurtleSide.LEFT) instanceof TurtleChatBox) {
+                    ServerComputer computer = tileTurtle.getServerComputer();
+
+                    if (computer == null)
+                        return;
+
                     if (event.getMessage().startsWith("$")) {
                         event.setCanceled(true);
-                        tileTurtle.getServerComputer().queueEvent("chat", new Object[]{event.getUsername(), event.getMessage().replace("$", "")});
+                        computer.queueEvent("chat", new Object[]{event.getUsername(), event.getMessage().replace("$", "")});
                         return;
                     }
-                    tileTurtle.getServerComputer().queueEvent("chat", new Object[]{event.getUsername(), event.getMessage()});
+                    computer.queueEvent("chat", new Object[]{event.getUsername(), event.getMessage()});
                 }
             }
         });


### PR DESCRIPTION
It seems like there are cases where CC will return null for `getServerComputer`, my guess is it having to do with turtles somehow being placed in the world without a computer being created (maybe by structures?).

This PR should allow users to chat but the fact that there are tile entities without computers might need further investigation, but I don't really know both mods well enough so I cannot tell if it is needed. CC itself also has null-checks for return values of this function, so it's probably good to have anyways.