### PR TITLE
Fixed broken links

### DIFF
--- a/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/end_automata_core.json
+++ b/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/end_automata_core.json
@@ -13,7 +13,7 @@
     {
       "type": "link",
       "text": "In additions to weak automata core abilities, this soul also allow limited world-bound teleportation. Seems, you need to store points and then teleport to them!$(p)But be aware, any stored points will be lost after turtle is broken.",
-      "url": "https://docs.srendi.de/items/end_automata/",
+      "url": "https://docs.srendi.de/metaphysics/end_automata/",
       "link_text": "API documentation"
     }
   ]

--- a/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/husbandry_automata_core.json
+++ b/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/husbandry_automata_core.json
@@ -13,7 +13,7 @@
     {
       "type": "link",
       "text": "In additions to weak automata core abilities, this core also allow to interact with animals and even transfer them inside!$(p)But be aware, any stored animal will be lost after turtle is broken.",
-      "url": "https://docs.srendi.de/items/husbandry_automata/",
+      "url": "https://docs.srendi.de/metaphysics/husbandry_automata/",
       "link_text": "API documentation"
     }
   ]

--- a/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/overpowered_automata_core.json
+++ b/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/overpowered_automata_core.json
@@ -18,7 +18,7 @@
     {
       "type": "link",
       "text": "Overpowered versions of automata cores doesn't consumes item durability when use it.$(p)But everything come for price. If you try to perform any operation with this core without enough fuel - upgrade will broke immediately.",
-      "url": "https://docs.srendi.de/items/overpowered_automata/",
+      "url": "https://docs.srendi.de/metaphysics/overpowered_automata/",
       "link_text": "API documentation"
     }
   ]

--- a/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/weak_automata_core.json
+++ b/src/main/resources/data/advancedperipherals/patchouli_books/manual/en_us/entries/metaphysics/weak_automata_core.json
@@ -16,7 +16,7 @@
     {
       "type": "link",
       "text": "It provides several ability for turtles.$(li)Digging block with tool;$(li)Click on block with item or empty hand;$(li)Suck item around, all or specific;$(li)Detect items around;$(li)Detect block or turtle in line of view;$(li)Charge turtle with RF item inside inventory",
-      "url": "https://docs.srendi.de/items/weak_automata/",
+      "url": "https://docs.srendi.de/metaphysics/weak_automata/",
       "link_text": "API documentation"
     },
     {


### PR DESCRIPTION
All of the metaphysics items in the book recently added seem to point to the items/ subdirectory for api documentation, but the api documentation for these turtles is actually under the metaphysics/ subdirectory