### PR TITLE
Fix: use correct bit mask for fixing argb alphas (AR goggles)

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/argoggles/ARRenderHelper.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/argoggles/ARRenderHelper.java
@@ -28,7 +28,7 @@ public class ARRenderHelper extends AbstractGui {
     }
 
     public static int fixAlpha(int color) {
-        return (color & -67108864) == 0 ? color | -16777216 : color;
+        return (color & 0xFF000000) == 0 ? color | 0xFF000000 : color;
     }
 
     @Override


### PR DESCRIPTION
The bit mask used in the conditional was 0xFC000000, which leaves two bits unchecked. So alpha values at 0x03 and below would be made solid. The new mask only fixes the alpha value if it's truly zero.

Here are screenshots before and after the fix. Both are using 0x03FF00FF (very transparent purple) as the color. Before, the color would erroneously be made solid. After, it remains a very faint purple.

![2021-08-24_22 42 21](https://user-images.githubusercontent.com/748280/130733199-06afcf17-7ead-4808-9cf8-0fb0cec66f8b.png)

![2021-08-24_22 41 44](https://user-images.githubusercontent.com/748280/130733203-a7a51836-1f2c-4d25-819a-e0029075ab3f.png)

I also changed both literals to hex values so it's easier to see what's going on.

It's a very tiny bug but I think if someone were writing a project where they produce colors programmatically (like, say, a rasterizer), having to clamp calculated alphas at 1 makes a bit more sense than 4.