### PR TITLE
Add ability to get max item/fluid disk/external storage space.

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RsBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RsBridgePeripheral.java
@@ -59,6 +59,24 @@ public class RsBridgePeripheral extends BasePeripheral<TileEntityPeripheralOwner
     }
 
     @LuaFunction(mainThread = true)
+    public final Integer getMaxItemDiskStorage() {
+        return RefinedStorage.getMaxItemDiskStorage(getNetwork());
+    }
+    @LuaFunction(mainThread = true)
+    public final Integer getMaxFluidDiskStorage() {
+        return RefinedStorage.getMaxFluidDiskStorage(getNetwork());
+    }
+
+    @LuaFunction(mainThread = true)
+    public final Integer getMaxItemExternalStorage() {
+        return RefinedStorage.getMaxItemExternalStorage(getNetwork());
+    }
+    @LuaFunction(mainThread = true)
+    public final Integer getMaxFluidExternalStorage() {
+        return RefinedStorage.getMaxFluidExternalStorage(getNetwork());
+    }
+
+    @LuaFunction(mainThread = true)
     public final Object listFluids() {
         return RefinedStorage.listFluids(false, getNetwork());
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/refinedstorage/RefinedStorage.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/refinedstorage/RefinedStorage.java
@@ -4,7 +4,10 @@ import com.refinedmods.refinedstorage.api.IRSAPI;
 import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
 import com.refinedmods.refinedstorage.api.network.INetwork;
 import com.refinedmods.refinedstorage.api.network.node.INetworkNode;
+import com.refinedmods.refinedstorage.api.storage.IStorage;
 import com.refinedmods.refinedstorage.api.storage.cache.IStorageCache;
+import com.refinedmods.refinedstorage.api.storage.disk.IStorageDisk;
+import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStorage;
 import com.refinedmods.refinedstorage.api.util.StackListEntry;
 import com.refinedmods.refinedstorage.apiimpl.API;
 import com.refinedmods.refinedstorage.apiimpl.network.node.NetworkNode;
@@ -90,6 +93,50 @@ public class RefinedStorage {
             items.add(map);
         }
         return items;
+    }
+
+    public static Integer getMaxItemDiskStorage(INetwork network) {
+        int total = 0;
+        boolean creative = false;
+        for(IStorage<ItemStack> store : network.getItemStorageCache().getStorages()) {
+            if(store instanceof IStorageDisk) {
+                int cap = ((IStorageDisk<ItemStack>) store).getCapacity();
+                if(cap > 0) total += cap;
+                else creative = true;
+            }
+        }
+        return creative ? -1 : total;
+    }
+    public static Integer getMaxFluidDiskStorage(INetwork network) {
+        int total = 0;
+        boolean creative = false;
+        for(IStorage<FluidStack> store : network.getFluidStorageCache().getStorages()) {
+            if(store instanceof IStorageDisk) {
+                int cap = ((IStorageDisk<FluidStack>) store).getCapacity();
+                if(cap > 0) total += cap;
+                else creative = true;
+            }
+        }
+        return creative ? -1 : total;
+    }
+
+    public static Integer getMaxItemExternalStorage(INetwork network) {
+        int total = 0;
+        for(IStorage<ItemStack> store : network.getItemStorageCache().getStorages()) {
+            if(store instanceof IExternalStorage) {
+                total += ((IExternalStorage<ItemStack>) store).getCapacity();
+            }
+        }
+        return total;
+    }
+    public static Integer getMaxFluidExternalStorage(INetwork network) {
+        int total = 0;
+        for(IStorage<FluidStack> store : network.getFluidStorageCache().getStorages()) {
+            if(store instanceof IExternalStorage) {
+                total += ((IExternalStorage<FluidStack>) store).getCapacity();
+            }
+        }
+        return total;
     }
 
     public static Object getObjectFromPattern(ICraftingPattern pattern) {


### PR DESCRIPTION
Added getMaxItemDiskStorage and getMaxFluidDiskStorage as mentioned in SirEndii/Advanced-Peripherals-Features#51.
Both functions return -1 if there is a creative storage disk (as they don't have a max capacity).
Tested using a 1k, 64k, and creative storage disk in one Disk Drive connected to a creative Controller.

Also added getMaxItemExternalStorage and getMaxFluidExternalStorage, not mentioned in the original issue, however requested in the discord server.
Tested using an external storage adapter on a single and double chest connected to a creative controller.

I am not going to implement a function to combine the max disk and external storages as it is redundant, and can be done lua-side.

*also probably good to note this adds for refined storage only, not AE*