### PR TITLE
fix #251

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
@@ -10,6 +10,7 @@ import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class BlockReaderPeripheral extends BasePeripheral<BlockEntityPeripheralOwner<BlockReaderTile>> {
@@ -36,8 +37,14 @@ public class BlockReaderPeripheral extends BasePeripheral<BlockEntityPeripheralO
     public final Object getBlockData() {
         if (getBlockInFront().is(Blocks.AIR) && !(getBlockInFront().getBlock() instanceof EntityBlock))
             return null;
-        return NBTUtil.toLua(getLevel().getBlockEntity(getPos().relative(getLevel().getBlockState(getPos()).
-                getValue(APTileEntityBlock.FACING))).save(new CompoundTag()));
+        BlockEntity target = getLevel().getBlockEntity(
+                getPos().relative(
+                        getLevel().getBlockState(getPos()).getValue(
+                                APTileEntityBlock.FACING
+                        )
+                )
+        );
+        return NBTUtil.toLua(target.save(target.saveWithoutMetadata()));
     }
 
     private BlockState getBlockInFront() {


### PR DESCRIPTION
I have fixed my self found bug. I don't know why this is handled so strange in 1.18 but 'save' saves only the metadata and 'saveWithoutMetadata' saves the rest. I tested it ingame with a vanilla BlockEntity (Barrel).

![image](https://user-images.githubusercontent.com/23450823/148620506-c480fab0-1250-466a-ba0b-a68709794d7f.png)
