### PR TITLE
Added ids to AR Renderer

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ARControllerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ARControllerPeripheral.java
@@ -50,8 +50,18 @@ public class ARControllerPeripheral extends BasePeripheral<BlockEntityPeripheral
     }
 
     @LuaFunction(mainThread = true)
+    public final void drawStringWithId(String id, String text, int x, int y, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.DrawString, text, x, y, color));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void drawCenteredString(String text, int x, int y, int color) {
         owner.tileEntity.addToCanvas(new ARRenderAction(RenderActionType.DrawCenteredString, text, x, y, color));
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void drawCenteredStringWithId(String id, String text, int x, int y, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.DrawCenteredString, text, x, y, color));
     }
 
     @LuaFunction(mainThread = true)
@@ -60,8 +70,18 @@ public class ARControllerPeripheral extends BasePeripheral<BlockEntityPeripheral
     }
 
     @LuaFunction(mainThread = true)
+    public final void drawRightboundStringWithId(String id, String text, int x, int y, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.DrawRightboundString, text, x, y, color));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void horizontalLine(int minX, int maxX, int y, int color) {
         owner.tileEntity.addToCanvas(new ARRenderAction(RenderActionType.HorizontalLine, minX, maxX, y, color));
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void horizontalLineWithId(String id, int minX, int maxX, int y, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.HorizontalLine, minX, maxX, y, color));
     }
 
     @LuaFunction(mainThread = true)
@@ -70,8 +90,18 @@ public class ARControllerPeripheral extends BasePeripheral<BlockEntityPeripheral
     }
 
     @LuaFunction(mainThread = true)
+    public final void verticalLineWithId(String id, int x, int minY, int maxY, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.VerticalLine, x, minY, maxY, color));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void fill(int minX, int minY, int maxX, int maxY, int color) {
         owner.tileEntity.addToCanvas(new ARRenderAction(RenderActionType.Fill, minX, minY, maxX, maxY, color));
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void fillWithId(String id, int minX, int minY, int maxX, int maxY, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.Fill, minX, minY, maxX, maxY, color));
     }
 
     @LuaFunction(mainThread = true)
@@ -80,8 +110,18 @@ public class ARControllerPeripheral extends BasePeripheral<BlockEntityPeripheral
     }
 
     @LuaFunction(mainThread = true)
+    public final void fillGradientWithId(String id, int minX, int minY, int maxX, int maxY, int colorFrom, int colorTo) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.FillGradient, minX, minY, maxX, maxY, colorFrom, colorTo));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void drawCircle(int x, int y, int radius, int color) {
         owner.tileEntity.addToCanvas(new ARRenderAction(RenderActionType.DrawCircle, x, y, radius, color));
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void drawCircleWithId(String id, int x, int y, int radius, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.DrawCircle, x, y, radius, color));
     }
 
     @LuaFunction(mainThread = true)
@@ -90,12 +130,27 @@ public class ARControllerPeripheral extends BasePeripheral<BlockEntityPeripheral
     }
 
     @LuaFunction(mainThread = true)
+    public final void fillCircleWithId(String id, int x, int y, int radius, int color) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.FillCircle, x, y, radius, color));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void drawItemIcon(String itemId, int x, int y) {
         owner.tileEntity.addToCanvas(new ARRenderAction(RenderActionType.DrawItemIcon, itemId, x, y));
     }
 
     @LuaFunction(mainThread = true)
+    public final void drawItemIconWithId(String id, String itemId, int x, int y) {
+        owner.tileEntity.addToCanvas(new ARRenderAction(id, RenderActionType.DrawItemIcon, itemId, x, y));
+    }
+
+    @LuaFunction(mainThread = true)
     public final void clear() {
         owner.tileEntity.clearCanvas();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void clearElement(String id) {
+        owner.tileEntity.clearElement(id);
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/argoggles/ARRenderAction.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/argoggles/ARRenderAction.java
@@ -16,6 +16,7 @@ public final class ARRenderAction implements INBTSerializable<CompoundTag> {
     private static final String INT_ARGS = "int_args";
     private static final String VIRTUAL_SCREEN_SIZE = "virtualScreenSize";
 
+    private String id;
     private RenderActionType type;
     private String stringArg = "";
     private int[] intArgs = new int[0];
@@ -25,15 +26,28 @@ public final class ARRenderAction implements INBTSerializable<CompoundTag> {
 
     }
 
-    public ARRenderAction(RenderActionType type, int... intArgs) {
+    public ARRenderAction(String id, RenderActionType type, int... intArgs) {
         this();
+        this.id = id;
         this.type = type;
         this.intArgs = intArgs;
     }
 
+    public ARRenderAction(RenderActionType type, int... intArgs) {
+        this(null, type, intArgs);
+    }
+
     public ARRenderAction(RenderActionType type, String stringArg, int... intArgs) {
-        this(type, intArgs);
+        this(null, type, stringArg, intArgs);
+    }
+
+    public ARRenderAction(String id, RenderActionType type, String stringArg, int... intArgs) {
+        this(id, type, intArgs);
         this.stringArg = stringArg;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public static ARRenderAction deserialize(CompoundTag nbt) {

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/tileentity/ARControllerTile.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/tileentity/ARControllerTile.java
@@ -37,12 +37,20 @@ public class ARControllerTile extends PeripheralTileEntity<ARControllerPeriphera
     public void addToCanvas(ARRenderAction action) {
         if (canvas.contains(action))
             return;
+        if (action.getId() != null) {
+            canvas.removeIf(old -> action.getId().equals(old.getId()));
+        }
         canvas.add(action);
         blockChanged();
     }
 
     public void clearCanvas() {
         canvas.clear();
+        blockChanged();
+    }
+
+    public void clearElement(String id) {
+        canvas.removeIf(old -> id.equals(old.getId()));
         blockChanged();
     }
 


### PR DESCRIPTION
I added ids for render actions as I suggested in #263 

Here are 2 scripts that I tested it with and to show off what it can be used for.
Example 1: This one is a clock that shows up in the top left, it requires both an AR controller and an environment detector
```lua
local controller = peripheral.find('arController')
local detector = peripheral.find("environmentDetector")
 
controller.drawItemIcon("minecraft:clock", 4, 4)
 
while true do
    local timeseconds = math.floor((detector.getTime() % 24000) / 20)
 
    local endTime
    local endTimeNum = math.floor(60*((timeseconds / 60) % 1))
    if endTimeNum < 10 then
        endTime = "0" .. tostring(endTimeNum)
    else
        endTime = tostring(endTimeNum)
    end
 
    controller.drawStringWithId("clock_text", tostring(math.floor(timeseconds / 60)) .. ":" .. endTime, 20, 8, 16777215)
 
    os.sleep(0.25)
end
```
Explanation: if this were done without the drawStringWithId you would need to rerender the clock each time because you would need to do a global clear and that clear would make the text and clock flash.

Example 2: Shows a clock and text that reads "Screen Text" for 5s before removing the text and leaving the clock
```lua
local controller = peripheral.find('arController')
controller.drawItemIcon("minecraft:clock", 4, 4)
controller.drawStringWithId("text", "Screen Text", 20, 8, 0xff00ff)
os.sleep(5)
controller.clearElement("text")
```
Explanation: if this were done without the drawStringWithId again you would need to clear the whole thing and then rerender the clock if you wanted the keep the clock.