### PR TITLE
Geo Scanner height, fixes issue #266

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/GeoScannerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/GeoScannerPeripheral.java
@@ -108,7 +108,7 @@ public class GeoScannerPeripheral extends BasePeripheral<IPeripheralOwner> {
             HashMap<String, Integer> data = new HashMap<>();
             for (int x = chunkPos.getMinBlockX(); x <= chunkPos.getMaxBlockX(); x++) {
                 for (int z = chunkPos.getMinBlockZ(); z <= chunkPos.getMaxBlockZ(); z++) {
-                    for (int y = 0; y < 256; y++) {
+                    for (int y = level.dimensionType().minY(); y < level.dimensionType().height(); y++) {
                         BlockState block = chunk.getBlockState(new BlockPos(x, y, z));
                         ResourceLocation name = block.getBlock().getRegistryName();
                         if (name != null) {


### PR DESCRIPTION
Fixed an issue where the geo scanner would not make use of 1.18 terrain heights in the overworld. This should work for every dimension regardless of its height. 

This should also fix #266.