### PR TITLE
Update Forge and Create version, also change min Create version to fix #469

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.logging.level=info
 
 # Minecraft related
 minecraft_version=1.18.2
-forge_version=40.2.0
+forge_version=40.2.4
 mod_version=0.7.30r
 release_type=release
 mappings_channel=parchment
@@ -27,7 +27,7 @@ patchouli_version=1.18.2-72-SNAPSHOT
 refinedstorage_version=1.10.2
 mekanism_version=1.18.2-10.2.5.465
 botania_version=1.18.2-435
-create_version=0.5.1.a-279
+create_version=0.5.1.b-285
 ae2things_version=4096819
 
 # Mod dependencies which are needed for other mods

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -71,6 +71,6 @@ side = "BOTH"
 [[dependencies.advancedperipherals]]
 modId = "create"
 mandatory = false
-versionRange = "[0.5.1a,)"
+versionRange = "[0.5.1,)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
The min version of Create seems invalid, the latest version (0.5.1.b) doesn't seem to work like this as seen in #469. After changing the min version I also tried to run the mod with the latest build available via the Create Maven repo but it also requires a newer Forge version, which is why I changed these two too.