### PR TITLE
Fix MineColonies getResearch, add citizen job

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ColonyPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ColonyPeripheral.java
@@ -18,6 +18,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.pocket.IPocketAccess;
+import de.srendi.advancedperipherals.AdvancedPeripherals;
 import de.srendi.advancedperipherals.common.addons.computercraft.owner.BlockEntityPeripheralOwner;
 import de.srendi.advancedperipherals.common.addons.computercraft.owner.IPeripheralOwner;
 import de.srendi.advancedperipherals.common.addons.computercraft.owner.PocketPeripheralOwner;
@@ -200,14 +201,20 @@ public class ColonyPeripheral extends BasePeripheral<IPeripheralOwner> {
     }
 
     @LuaFunction(mainThread = true)
-    public final Object getResearch() throws LuaException, CommandSyntaxException {
+    public final Object getResearch() throws LuaException {
         IColony colony = getColony();
 
         IGlobalResearchTree globalTree = IGlobalResearchTree.getInstance();
 
         Map<String, Object> result = new HashMap<>();
-        for (ResourceLocation branch : globalTree.getBranches())
-            result.put(branch.toString(), MineColonies.getResearch(branch, globalTree.getPrimaryResearch(branch), colony));
+        for (ResourceLocation branch : globalTree.getBranches()) {
+            try {
+                result.put(branch.toString(), MineColonies.getResearch(branch, globalTree.getPrimaryResearch(branch), colony));
+            } catch (CommandSyntaxException ex) {
+                AdvancedPeripherals.debug("Error getting research for branch " + branch.toString() + ": " + ex.getMessage(), org.apache.logging.log4j.Level.WARN);
+                ex.printStackTrace();
+            }
+        }
 
         return result;
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/minecolonies/MineColonies.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/minecolonies/MineColonies.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IVisitorData;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.managers.interfaces.IRegisteredStructureManager;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.colony.workorders.IWorkOrder;
@@ -74,7 +75,7 @@ public class MineColonies {
         map.put("saturation", citizen.getSaturation());
         map.put("happiness", citizen.getCitizenHappinessHandler().getHappiness(citizen.getColony(), citizen));
         map.put("skills", skillsToObject(citizen.getCitizenSkillHandler().getSkills()));
-        map.put("work", citizen.getWorkBuilding() == null ? null : jobToObject(citizen.getWorkBuilding()));
+        map.put("work", citizen.getWorkBuilding() == null ? null : jobToObject(citizen.getWorkBuilding(), citizen.getJob()));
         map.put("home", citizen.getHomeBuilding() == null ? null : homeToObject(citizen.getHomeBuilding()));
         map.put("betterFood", citizen.needsBetterFood());
         map.put("isAsleep", map.get("state").toString().toLowerCase().contains("sleeping"));
@@ -111,17 +112,19 @@ public class MineColonies {
     }
 
     /**
-     * Converts a job {@link IBuilding} to a map
+     * Converts a building {@link IBuilding} and job {@link IJob} to a map
      *
      * @param work the home building
-     * @return a map with information about the job building
+     * @param job the job
+     * @return a map with information about the building and job
      */
-    public static Object jobToObject(IBuilding work) {
+    public static Object jobToObject(IBuilding work, IJob<?> job) {
         Map<String, Object> map = new HashMap<>();
         map.put("location", LuaConverter.posToObject(work.getLocation().getInDimensionLocation()));
         map.put("type", work.getSchematicName());
         map.put("level", work.getBuildingLevel());
         map.put("name", work.getBuildingDisplayName());
+        map.put("job", job.getJobRegistryEntry().getTranslationKey());
 
         return map;
     }


### PR DESCRIPTION
Some fixes for the colony integrator:

## Citizen job
* add `job` to citizen's `work` table, to distinguish different jobs that can be in the same building 

Example:
```lua
    work = {
      type = "guardtower",
      name = "com.minecolonies.building.guardtower",
      location = {
        y = 90,
        x = 68,
        z = 277,
      },
      level = 1,
      job = "com.minecolonies.job.knight",
    },
```

## Fixes and additions to `getResearch`
* `getResearch` function is callable again (was not available because it was throwing a non-lua exception)
* will not return hidden research items
* fix text properties of research: `name` and `researchEffects`
* add properties to research:
  * `requirements`: list of requirements:
    * `desc`: requirement description text 
    *  `type`: type of requirement, only `building` type shows additional information (`building` and `level`)
  * `cost`: list of research cost
  * `progress`: integer value


Example:
```
{
  status = "NOT_STARTED",
  id = "minecolonies:civilian/ambition",
  name = "Ambition",
  cost = {
    {
      name = "minecraft:diamond",
      maxStackSize = 64,
      tags = {
        "minecraft:item/forge:gems/diamond",
        "minecraft:item/twilightforest:portal/activator",
        "minecraft:item/minecolonies:reduceable_ingredient",
        "minecraft:item/minecraft:beacon_payment_items",
        "minecraft:item/balm:gems",
        "minecraft:item/balm:diamonds",
        "minecraft:item/forge:gems",
      },
      count = 1,
      nbt = {},
      displayName = "   [Diamond]",
    },
  },
  requirements = {},
  progress = 0,
  children = {
    {
      status = "NOT_STARTED",
      name = "Scuba",
      cost = {
        {
          name = "minecraft:heart_of_the_sea",
          maxStackSize = 64,
          tags = {},
          count = 1,
          nbt = {},
          displayName = "   [Heart of the Sea]",
        },
      },
      progress = 0,
      id = "minecolonies:civilian/air",
      requirements = {},
      researchEffects = {
        "Citizens can stay longer underwater",
      },
    },
  },
  researchEffects = {
    "Unlocks Mystical Site",
  },
},
{
  status = "NOT_STARTED",
  id = "minecolonies:civilian/firstaid",
  name = "First Aid",
  cost = {
    {
      name = "minecraft:hay_block",
      maxStackSize = 64,
      tags = {
        "minecraft:item/minecolonies:reduceable_product_excluded",
        "minecraft:item/minecolonies:blacksmith_ingredient_excluded",
        "minecraft:item/minecolonies:farmer_product",
        "minecraft:item/minecolonies:stonemason_ingredient_excluded",
        "minecraft:item/minecolonies:storage_blocks",
        "minecraft:item/minecolonies:stonemason_product_excluded",
        "minecraft:item/minecolonies:mechanic_product",
        "minecraft:item/minecolonies:mechanic_ingredient",
        "minecraft:item/minecolonies:sawmill_product_excluded",
        "minecraft:item/minecolonies:mechanic_product_excluded",
        "minecraft:item/minecolonies:blacksmith_product_excluded",
        "minecraft:item/minecolonies:farmer_ingredient",
        "minecraft:item/naturalist:giraffe_food_items",
      },
      count = 1,
      nbt = {},
      displayName = "   [Hay Bale]",
    },
  },
  requirements = {
    {
      type = "building",
      building = "townhall",
      level = 1,
      fulfilled = false,
      desc = "Requires Town Hall(s) totaling at least 1 levels!",
    },
  },
  progress = 0,
  children = {
    -- removed for readability
  },
  researchEffects = {
    "Citizen HP +2.0",
  },
},
```
