### PR TITLE
Add Powah's Ender Cell support

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
@@ -1,0 +1,53 @@
+package de.srendi.advancedperipherals.common.addons.powah;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.NotNull;
+import owmii.powah.block.ender.EnderCellTile;
+
+public class EnderCellIntegration extends BlockEntityIntegrationPeripheral<EnderCellTile> {
+    protected EnderCellIntegration(BlockEntity entity) {
+        super(entity);
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "enderCell";
+    }
+
+    @LuaFunction(mainThread = true)
+    public final String getName() {
+        return "Ender Cell";
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getEnergy() {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getMaxEnergy() {
+        return blockEntity.getEnergy().getMaxEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final int getChannel() {
+        // Lua, and generally slots in MC, seem to be 1 based, make the conversion here
+        int channel = blockEntity.getChannel().get();
+        return channel + 1;
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void setChannel(int channel) {
+        // Lua, and generally slots in MC, seem to be 1 based, make the conversion here
+        channel = channel - 1;
+        blockEntity.getChannel().set(channel);
+    }
+
+    @LuaFunction(mainThread = true)
+    public final int getMaxChannels() {
+        return blockEntity.getMaxChannels();
+    }
+}

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/Integration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/Integration.java
@@ -2,6 +2,7 @@ package de.srendi.advancedperipherals.common.addons.powah;
 
 import de.srendi.advancedperipherals.common.addons.computercraft.integrations.IntegrationPeripheralProvider;
 import owmii.powah.block.energycell.EnergyCellTile;
+import owmii.powah.block.ender.EnderCellTile;
 import owmii.powah.block.furnator.FurnatorTile;
 import owmii.powah.block.magmator.MagmatorTile;
 import owmii.powah.block.reactor.ReactorPartTile;
@@ -13,6 +14,7 @@ public class Integration implements Runnable {
     public void run() {
         IntegrationPeripheralProvider.registerBlockEntityIntegration(ReactorIntegration::new, ReactorPartTile.class);
         IntegrationPeripheralProvider.registerBlockEntityIntegration(EnergyCellIntegration::new, EnergyCellTile.class);
+        IntegrationPeripheralProvider.registerBlockEntityIntegration(EnderCellIntegration::new, EnderCellTile.class);
         IntegrationPeripheralProvider.registerBlockEntityIntegration(SolarPanelIntegration::new, SolarTile.class);
         IntegrationPeripheralProvider.registerBlockEntityIntegration(FurnatorIntegration::new, FurnatorTile.class);
         IntegrationPeripheralProvider.registerBlockEntityIntegration(MagmatorIntegration::new, MagmatorTile.class);


### PR DESCRIPTION
Add support for Powah's Ender Cell energy storage block.

- Includes energy reading (current, max)
- Includes channel reading (current, max)
- Include channel setting

Channel support forced into 1-index based to match more conventional MC and Lua conventions.