### PR TITLE
Fix the missing tag when try to insert item in the AE2 system.

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/MeItemHandler.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/MeItemHandler.java
@@ -30,7 +30,7 @@ public class MeItemHandler implements IStorageSystemItemHandler {
     @NotNull
     @Override
     public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-        AEItemKey itemKey = AEItemKey.of(stack.getItem());
+        AEItemKey itemKey = AEItemKey.of(stack.getItem(), stack.getOrCreateTag());
         long inserted = storageMonitor.insert(itemKey, stack.getCount(), simulate ? Actionable.SIMULATE : Actionable.MODULATE, actionSource);
         ItemStack insertedStack = stack.copy();
         // Safe to cast here, the amount will never be higher than 64


### PR DESCRIPTION
Partially resolve #503 as AE2 seems to not accept inserting of cells with items inside. 
I didn't find any documentation about this.