### PR TITLE
Some cleanup of connected computer handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,10 @@ repositories {
     maven {
         name = "Squiddev maven cct"
         url = 'https://squiddev.cc/maven/'
+        content {
+            includeGroup("cc.tweaked")
+            includeModule("org.squiddev", "Cobalt")
+        }
     }
     maven {
         name = "Theillusivec4 maven curios"

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/TurtleFuelAbility.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/TurtleFuelAbility.java
@@ -1,6 +1,5 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.owner;
 
-import dan200.computercraft.shared.config.Config;
 import org.jetbrains.annotations.NotNull;
 
 public class TurtleFuelAbility extends FuelAbility<TurtlePeripheralOwner> {
@@ -23,7 +22,7 @@ public class TurtleFuelAbility extends FuelAbility<TurtlePeripheralOwner> {
 
     @Override
     public boolean isFuelConsumptionDisable() {
-        return Config.turtlesNeedFuel;
+        return owner.getTurtle().isFuelNeeded();
     }
 
     @Override

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -5,6 +5,7 @@ import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
+import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.pocket.IPocketAccess;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.TurtleSide;
@@ -15,6 +16,7 @@ import de.srendi.advancedperipherals.common.addons.computercraft.owner.PocketPer
 import de.srendi.advancedperipherals.common.addons.computercraft.owner.TurtlePeripheralOwner;
 import de.srendi.advancedperipherals.common.blocks.base.PeripheralBlockEntity;
 import de.srendi.advancedperipherals.common.configuration.APConfig;
+import de.srendi.advancedperipherals.common.events.Events;
 import de.srendi.advancedperipherals.common.util.CoordUtil;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import de.srendi.advancedperipherals.lib.peripherals.IPeripheralFunction;
@@ -35,9 +37,12 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public static final String PERIPHERAL_TYPE = "chatBox";
 
+    private long lastConsumedMessage;
+
     protected ChatBoxPeripheral(IPeripheralOwner owner) {
         super(PERIPHERAL_TYPE, owner);
         owner.attachOperation(CHAT_MESSAGE);
+        lastConsumedMessage = Events.getLastChatMessageID() - 1;
     }
 
     public ChatBoxPeripheral(PeripheralBlockEntity<?> tileEntity) {
@@ -199,6 +204,14 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
                 player.sendSystemMessage(preparedMessage, false);
             return MethodResult.of(true);
+        });
+    }
+
+    public void update() {
+        lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> {
+            for (IComputerAccess computer : getConnectedComputers()) {
+                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden());
+            }
         });
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/turtles/TurtleChatBoxUpgrade.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/turtles/TurtleChatBoxUpgrade.java
@@ -1,9 +1,8 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.turtles;
 
+import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.TurtleSide;
-import dan200.computercraft.shared.computer.core.ServerComputer;
-import dan200.computercraft.shared.turtle.blocks.TurtleBlockEntity;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
 import de.srendi.advancedperipherals.common.addons.computercraft.peripheral.ChatBoxPeripheral;
 import de.srendi.advancedperipherals.common.events.Events;
@@ -11,16 +10,11 @@ import de.srendi.advancedperipherals.lib.turtle.PeripheralTurtleUpgrade;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 
 public class TurtleChatBoxUpgrade extends PeripheralTurtleUpgrade<ChatBoxPeripheral> {
-
-    private long lastConsumedMessage;
-
     public TurtleChatBoxUpgrade(ResourceLocation id, ItemStack item) {
         super(id, item);
-        lastConsumedMessage = Events.getLastChatMessageID() - 1;
     }
 
     @Override
@@ -44,13 +38,6 @@ public class TurtleChatBoxUpgrade extends PeripheralTurtleUpgrade<ChatBoxPeriphe
         if (turtle.getLevel().isClientSide)
             return;
 
-        if (turtle.getUpgrade(side) instanceof TurtleChatBoxUpgrade) {
-            BlockEntity tile = turtle.getLevel().getBlockEntity(turtle.getPosition());
-            if (tile instanceof TurtleBlockEntity tileTurtle) {
-                ServerComputer computer = tileTurtle.getServerComputer();
-                lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> computer.queueEvent("chat", new Object[]{message.username(), message.message(), message.uuid(), message.isHidden()}));
-
-            }
-        }
+        if (turtle.getPeripheral(side) instanceof ChatBoxPeripheral chatBox) chatBox.update();
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/turtles/TurtleChatBoxUpgrade.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/turtles/TurtleChatBoxUpgrade.java
@@ -1,11 +1,9 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.turtles;
 
-import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.TurtleSide;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
 import de.srendi.advancedperipherals.common.addons.computercraft.peripheral.ChatBoxPeripheral;
-import de.srendi.advancedperipherals.common.events.Events;
 import de.srendi.advancedperipherals.lib.turtle.PeripheralTurtleUpgrade;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
@@ -38,6 +36,8 @@ public class TurtleChatBoxUpgrade extends PeripheralTurtleUpgrade<ChatBoxPeriphe
         if (turtle.getLevel().isClientSide)
             return;
 
-        if (turtle.getPeripheral(side) instanceof ChatBoxPeripheral chatBox) chatBox.update();
+        if (turtle.getPeripheral(side) instanceof ChatBoxPeripheral chatBox) {
+            chatBox.update();
+        }
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/base/PeripheralBlockEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/base/PeripheralBlockEntity.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
-import java.util.List;
 
 public abstract class PeripheralBlockEntity<T extends BasePeripheral<?>> extends BaseContainerBlockEntity implements WorldlyContainer, MenuProvider, IPeripheralTileEntity {
     // TODO: move inventory logic to another tile entity!

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/base/PeripheralBlockEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/base/PeripheralBlockEntity.java
@@ -108,7 +108,7 @@ public abstract class PeripheralBlockEntity<T extends BasePeripheral<?>> extends
     @NotNull
     protected abstract T createPeripheral();
 
-    public List<IComputerAccess> getConnectedComputers() {
+    public Iterable<IComputerAccess> getConnectedComputers() {
         if (peripheral == null) // just avoid some NPE in strange cases
             return Collections.emptyList();
         return peripheral.getConnectedComputers();

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/ChatBoxEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/ChatBoxEntity.java
@@ -12,12 +12,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 public class ChatBoxEntity extends PeripheralBlockEntity<ChatBoxPeripheral> {
-
-    private Long lastConsumedMessage;
-
     public ChatBoxEntity(BlockPos pos, BlockState state) {
         super(BlockEntityTypes.CHAT_BOX.get(), pos, state);
-        lastConsumedMessage = Events.getLastChatMessageID() - 1;
     }
 
     @NotNull
@@ -28,6 +24,6 @@ public class ChatBoxEntity extends PeripheralBlockEntity<ChatBoxPeripheral> {
 
     @Override
     public <T extends BlockEntity> void handleTick(Level level, BlockState state, BlockEntityType<T> type) {
-        lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> getConnectedComputers().forEach(computer -> computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden())));
+        if (peripheral != null) peripheral.update();
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/ChatBoxEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/ChatBoxEntity.java
@@ -2,7 +2,6 @@ package de.srendi.advancedperipherals.common.blocks.blockentities;
 
 import de.srendi.advancedperipherals.common.addons.computercraft.peripheral.ChatBoxPeripheral;
 import de.srendi.advancedperipherals.common.blocks.base.PeripheralBlockEntity;
-import de.srendi.advancedperipherals.common.events.Events;
 import de.srendi.advancedperipherals.common.setup.BlockEntityTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -24,6 +23,8 @@ public class ChatBoxEntity extends PeripheralBlockEntity<ChatBoxPeripheral> {
 
     @Override
     public <T extends BlockEntity> void handleTick(Level level, BlockState state, BlockEntityType<T> type) {
-        if (peripheral != null) peripheral.update();
+        if (peripheral != null) {
+            peripheral.update();
+        }
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/lib/peripherals/BasePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/lib/peripherals/BasePeripheral.java
@@ -15,12 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public abstract class BasePeripheral<O extends IPeripheralOwner> implements IBasePeripheral<O>, IDynamicPeripheral {
 
-    protected final List<IComputerAccess> connectedComputers = new ArrayList<>();
+    protected final Set<IComputerAccess> connectedComputers = Collections.newSetFromMap(new ConcurrentHashMap<>());
     protected final String type;
     protected final O owner;
     protected final List<BoundMethod> pluggedMethods = new ArrayList<>();
@@ -63,7 +64,7 @@ public abstract class BasePeripheral<O extends IPeripheralOwner> implements IBas
     }
 
     @Override
-    public List<IComputerAccess> getConnectedComputers() {
+    public Iterable<IComputerAccess> getConnectedComputers() {
         return connectedComputers;
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/lib/peripherals/IBasePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/lib/peripherals/IBasePeripheral.java
@@ -4,12 +4,10 @@ import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import de.srendi.advancedperipherals.common.addons.computercraft.owner.IPeripheralOwner;
 
-import java.util.List;
-
 public interface IBasePeripheral<T extends IPeripheralOwner> extends IPeripheral {
     boolean isEnabled();
 
-    List<IComputerAccess> getConnectedComputers();
+    Iterable<IComputerAccess> getConnectedComputers();
 
     T getPeripheralOwner();
 }


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
The commit messages go into a bit more detail here, but in summary:

 - Converts the collection of connected computers to a concurrent set.
 - Move the handling of chat events to the peripheral, rather than having separate logic in the `BlockEntity` and turtle upgrade.

* **What is the current behaviour?** (You can also link to an open issue here)
 - There's a (small) risk of `ConcurrentModificationException`s when attaching/detaching computers.
 - Chat turtles only send a `chat` message to one turtle.

* **What is the new behaviour (if this is a feature change)?**
The above issues are fixed. No other observable changes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
This changes the method signature of `IBasePeripheral.getConnectedComputers`. I don't believe any other mods use this interface, but just worth mentioning.

* **Other information**:

I've also added a `content` filter to the squiddev.cc maven. I'd really recommend doing this to all your repositories - it significantly speeds up dependency fetching, as you don't need to query every maven repository for every dependency.