### PR TITLE
Add peripheral functions for the Dim Chest of the Dimensional Storage…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,12 @@ dependencies {
     implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:11.1.106")
     implementation fg.deobf("dev.architectury:architectury-forge:9.1.10")
 
+    //DimStorage
+    compileOnly fg.deobf("curse.maven:dimstorage-353882:${dimstorage_version}")
+    runtimeOnly fg.deobf("curse.maven:dimstorage-353882:${dimstorage_version}")
+    compileOnly fg.deobf("curse.maven:edivadlib-638508:${edivadlib_version}")
+    runtimeOnly fg.deobf("curse.maven:edivadlib-638508:${edivadlib_version}")
+
     //Removed until fully ported
     //testImplementation fg.deobf("site.siredvin.ttoolkit:ttoolkit-${minecraft_version}:${ttoolkit_version}")
 
@@ -320,6 +326,8 @@ dependencies {
     // Testing stuff
     // JEI
     implementation fg.deobf("mezz.jei:jei-${jei_version}")
+    // Jade
+    implementation fg.deobf("curse.maven:jade-324717:${jade_version}")
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,7 @@ powah_version=4638301
 ae2additions_version=4646598
 kotlinforforge_version=4.4.0
 appliedmekanistics_version=4842281
+dimstorage_version=4717497
 
 # Mod dependencies which are needed for other mods
 # For minecolonies
@@ -47,5 +48,9 @@ multipiston_version=1.19.3-1.2.26-ALPHA
 # For Create
 flywheel_version=0.6.8.a-1
 
+# For DimStorage
+edivadlib_version=4717006
+
 # Mod dependencies for testing stuff(Only used in the dev environment)
 jei_version=1.20.1-forge:15.2.0.22
+jade_version=4973483

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
 public class IntegrationPeripheralProvider implements IPeripheralProvider {
 
     //private static final String[] SUPPORTED_MODS = new String[]{"botania", "create", "mekanism", "powah"};
-    private static final String[] SUPPORTED_MODS = new String[]{"powah", "create", "mekanism"};
+    private static final String[] SUPPORTED_MODS = new String[]{"powah", "create", "mekanism", "dimstorage"};
 
     private static final PriorityQueue<IPeripheralIntegration> integrations = new PriorityQueue<>(Comparator.comparingInt(IPeripheralIntegration::getPriority));
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/DimChestIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/DimChestIntegration.java
@@ -21,7 +21,7 @@ public class DimChestIntegration extends BlockEntityIntegrationPeripheral<BlockE
         return "dimChest";
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public final String getOwnerUUID() {
         UUID uuid = blockEntity.getFrequency().getOwnerUUID();
         if (uuid == null)
@@ -29,22 +29,22 @@ public class DimChestIntegration extends BlockEntityIntegrationPeripheral<BlockE
         return uuid.toString();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public final String getOwner() {
         return blockEntity.getFrequency().getOwner();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public final boolean hasOwner() {
         return blockEntity.getFrequency().hasOwner();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public final int getChannel() {
         return blockEntity.getFrequency().getChannel();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public final boolean setChannel(int channel) {
         Frequency fre = blockEntity.getFrequency();
         if (fre.hasOwner()) return false;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/DimChestIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/DimChestIntegration.java
@@ -1,0 +1,55 @@
+package de.srendi.advancedperipherals.common.addons.dimstorage;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import edivad.dimstorage.api.Frequency;
+import edivad.dimstorage.blockentities.BlockEntityDimChest;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class DimChestIntegration extends BlockEntityIntegrationPeripheral<BlockEntityDimChest> {
+
+    protected DimChestIntegration(BlockEntity entity) {
+        super(entity);
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "dimChest";
+    }
+
+    @LuaFunction
+    public final String getOwnerUUID() {
+        UUID uuid = blockEntity.getFrequency().getOwnerUUID();
+        if (uuid == null)
+            return null;
+        return uuid.toString();
+    }
+
+    @LuaFunction
+    public final String getOwner() {
+        return blockEntity.getFrequency().getOwner();
+    }
+
+    @LuaFunction
+    public final boolean hasOwner() {
+        return blockEntity.getFrequency().hasOwner();
+    }
+
+    @LuaFunction
+    public final int getChannel() {
+        return blockEntity.getFrequency().getChannel();
+    }
+
+    @LuaFunction
+    public final boolean setChannel(int channel) {
+        Frequency fre = blockEntity.getFrequency();
+        if (fre.hasOwner()) return false;
+        fre.setChannel(channel);
+        blockEntity.setFrequency(fre);
+        return true;
+    }
+}

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/Integration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/dimstorage/Integration.java
@@ -1,0 +1,12 @@
+package de.srendi.advancedperipherals.common.addons.dimstorage;
+
+import de.srendi.advancedperipherals.common.addons.computercraft.integrations.IntegrationPeripheralProvider;
+import edivad.dimstorage.blockentities.BlockEntityDimChest;
+
+public class Integration implements Runnable {
+
+    @Override
+    public void run() {
+        IntegrationPeripheralProvider.registerBlockEntityIntegration(DimChestIntegration::new, BlockEntityDimChest.class);
+    }
+}


### PR DESCRIPTION
… mod. Also add Jade for better testing purposes.

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
The GUI configuration options of the dimensional chest from the dimensional storage mod are now exposed as a peripheral, which allows you to configure the chest as a peripheral.

* **What is the current behavior?** (You can also link to an open issue here)
The chest is exposed as a default inventory peripheral, allowing only to access it's inventory.

* **What is the new behavior (if this is a feature change)?**
The chest now exposes its configuration instead of the inventory.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
Technically, since now you can't access the inventory any more.

* **Other information**:
As we talked before, you still need to implement a way to expose the inventory and the configuration at the same time, since multiple peripheral exposures are not possible at the moment.
