### PR TITLE
Add random error to getPlayerPos

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -213,23 +213,37 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
 
         Map<String, Object> info = new HashMap<>();
 
-        double x = existingPlayer.getX();
-        double y = existingPlayer.getY();
-        double z = existingPlayer.getZ();
+        double x = existingPlayer.getX(), y = existingPlayer.getY(), z = existingPlayer.getZ();
 
         if (APConfig.PERIPHERALS_CONFIG.playerSpyRandError.get()) {
-            double distance = Math.sqrt(Math.pow(x - getPos().getX(), 2) + Math.pow(y - getPos().getY(), 2) + Math.pow(z - getPos().getZ(), 2));
+            // We apply random error to the returned player position if so enabled in the configuration.
 
-            final int minDistance = 50;
-            final int maxDistance = 10000;
-            final int maxError = 2500;
+            // minDistance: Below this distance, the player's exact position is returned
+            int minDistance = APConfig.PERIPHERALS_CONFIG.playerSpyPreciseMaxRange.get();
+            // maxError: The maximum amount of blocks that the player's position can be off by (on each axis) at the max distance
+            int maxError = APConfig.PERIPHERALS_CONFIG.playerSpyRandErrorAmount.get();
+            // maxDistance: At this distance, maximum error is applied. Hard-coded to the minimum of MAX_RANGE and 10000, or just 10000 if MAX_RANGE is unlimited
+            int maxDistance = MAX_RANGE == -1 ? 10000 : Math.min(MAX_RANGE, 10000);
+            // sublinearFactor: We apply exponent to the calculations so that error increases quickly at first before leveling out
+            // This is hard-coded so as not to overwhelm the player with configuration options, but this can probably be changed
+            double sublinearFactor = 0.8;
+            // yAxisWeight: Since the Y-axis obviously has a much smaller range than X- and Z- axes
+            // (which can theoretically be infinite) in the Minecraft world, we should apply less error to it
+            double yAxisWeight = (double) 1 / 4;
 
-            distance -= minDistance;
-            if (distance > 0) {
-                double error = maxError * Math.min(Math.pow(distance / maxDistance, 0.8), 1);
-                x += (Math.random()-0.5)*2 * error;
-                y += (Math.random()-0.5)*2 * (error / 4);
-                z += (Math.random()-0.5)*2 * error;
+            maxDistance = Math.max(minDistance, maxDistance);
+
+            // Calculate Euclidean distance between the player locator and the player in question
+            double distanceFromPlayer = Math.sqrt(Math.pow(x - getPos().getX(), 2) + Math.pow(y - getPos().getY(), 2) + Math.pow(z - getPos().getZ(), 2));
+
+            distanceFromPlayer -= minDistance;
+            if (distanceFromPlayer > 0) {
+                // We calculate error as the fraction of the player's distance and the max distance defined in the configuration
+                // then we raise it to sublinearFactor to make it somewhat exponential
+                double error = maxError * Math.min(Math.pow(distanceFromPlayer / maxDistance, sublinearFactor), 1);
+                x += (Math.random() - 0.5) * 2 * error;
+                y += (Math.random() - 0.5) * 2 * error * yAxisWeight;
+                z += (Math.random() - 0.5) * 2 * error;
             }
         }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -227,9 +227,9 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
             distance -= minDistance;
             if (distance > 0) {
                 double error = maxError * Math.min(Math.pow(distance / maxDistance, 0.5), 1);
-                x += Math.random() * error;
-                y += Math.random() * (error / 4);
-                z += Math.random() * error;
+                x += (Math.random()-0.5)*2 * error;
+                y += (Math.random()-0.5)*2 * (error / 4);
+                z += (Math.random()-0.5)*2 * error;
             }
         }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -212,9 +212,30 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
             return Collections.emptyMap();
 
         Map<String, Object> info = new HashMap<>();
-        info.put("x", Math.floor(existingPlayer.getX()));
-        info.put("y", Math.floor(existingPlayer.getY()));
-        info.put("z", Math.floor(existingPlayer.getZ()));
+
+        double x = existingPlayer.getX();
+        double y = existingPlayer.getY();
+        double z = existingPlayer.getZ();
+
+        if (APConfig.PERIPHERALS_CONFIG.playerSpyRandError.get()) {
+            double distance = Math.sqrt(Math.pow(x - getPos().getX(), 2) + Math.pow(y - getPos().getY(), 2) + Math.pow(z - getPos().getZ(), 2));
+
+            final int minDistance = 50;
+            final int maxDistance = 10000;
+            final int maxError = 2500;
+
+            distance -= minDistance;
+            if (distance > 0) {
+                double error = maxError * Math.min(Math.pow(distance / maxDistance, 0.5), 1);
+                x += Math.random() * error;
+                y += Math.random() * (error / 4);
+                z += Math.random() * error;
+            }
+        }
+
+        info.put("x", Math.floor(x));
+        info.put("y", Math.floor(y));
+        info.put("z", Math.floor(z));
         if (APConfig.PERIPHERALS_CONFIG.morePlayerInformation.get()) {
             info.put("yaw", existingPlayer.yRotO);
             info.put("pitch", existingPlayer.xRotO);

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -226,7 +226,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
 
             distance -= minDistance;
             if (distance > 0) {
-                double error = maxError * Math.min(Math.pow(distance / maxDistance, 0.5), 1);
+                double error = maxError * Math.min(Math.pow(distance / maxDistance, 0.8), 1);
                 x += (Math.random()-0.5)*2 * error;
                 y += (Math.random()-0.5)*2 * (error / 4);
                 z += (Math.random()-0.5)*2 * error;

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
@@ -16,6 +16,7 @@ public class PeripheralsConfig implements IAPConfig {
     public final ForgeConfigSpec.BooleanValue morePlayerInformation;
     public final ForgeConfigSpec.BooleanValue enablePlayerDetector;
     public final ForgeConfigSpec.BooleanValue playerDetMultiDimensional;
+    public final ForgeConfigSpec.BooleanValue playerSpyRandError;
 
     //Energy Detector
     public final ForgeConfigSpec.IntValue energyDetectorMaxFlow;
@@ -85,6 +86,7 @@ public class PeripheralsConfig implements IAPConfig {
         playerSpy = builder.comment("Activates the \"getPlayerPos\" function of the Player Detector").define("enablePlayerPosFunction", true);
         morePlayerInformation = builder.comment("Adds more information to `getPlayerPos` of the Player Detector. Like rotation and dimension").define("morePlayerInformation", true);
         playerDetMultiDimensional = builder.comment("If true, the player detector can observe players which aren't in the same dimension as the detector itself. `playerDetMaxRange` needs to be infinite(-1) for it to work.").define("chatBoxMultiDimensional", true);
+        playerSpyRandError = builder.comment("If true, add random error to `getPlayerPos` player position that varies based on how far the player is from the detector. Prevents getting the exact position of players far from the detector.").define("enablePlayerPosRandomError", false);
 
         pop("Energy_Detector", builder);
 

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
@@ -17,6 +17,8 @@ public class PeripheralsConfig implements IAPConfig {
     public final ForgeConfigSpec.BooleanValue enablePlayerDetector;
     public final ForgeConfigSpec.BooleanValue playerDetMultiDimensional;
     public final ForgeConfigSpec.BooleanValue playerSpyRandError;
+    public final ForgeConfigSpec.IntValue playerSpyRandErrorAmount;
+    public final ForgeConfigSpec.IntValue playerSpyPreciseMaxRange;
 
     //Energy Detector
     public final ForgeConfigSpec.IntValue energyDetectorMaxFlow;
@@ -87,6 +89,8 @@ public class PeripheralsConfig implements IAPConfig {
         morePlayerInformation = builder.comment("Adds more information to `getPlayerPos` of the Player Detector. Like rotation and dimension").define("morePlayerInformation", true);
         playerDetMultiDimensional = builder.comment("If true, the player detector can observe players which aren't in the same dimension as the detector itself. `playerDetMaxRange` needs to be infinite(-1) for it to work.").define("chatBoxMultiDimensional", true);
         playerSpyRandError = builder.comment("If true, add random error to `getPlayerPos` player position that varies based on how far the player is from the detector. Prevents getting the exact position of players far from the detector.").define("enablePlayerPosRandomError", false);
+        playerSpyRandErrorAmount = builder.comment("The maximum amount of error (in blocks) that can be applied to each axis of the player's position.").defineInRange("playerPosRandomErrorAmount", 1000, 0, Integer.MAX_VALUE);
+        playerSpyPreciseMaxRange = builder.comment("If random error is enabled: this is the maximum range at which an exact player position is returned, before random error starts to be applied.").defineInRange("playerPosPreciseMaxRange", 100, 0, Integer.MAX_VALUE);
 
         pop("Energy_Detector", builder);
 


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Calling `PlayerDetectorPeripheral.getPlayerPos` currently returns a player's exact position regardless of how far they are from the player detector.
As administrator of a server that uses this mod, I wanted to retain the ability to get a player's general position in the world, but I also wanted to maintain player privacy (such as avoiding exposing hidden bases) by not returning an exact position.

* **What is the new behavior (if this is a feature change)?**
This PR introduces random error to X, Y, and Z dimensions of a player's position that varies based on how far the player is from the player detector. The error multiplier increases sub-linearly based on Euclidean distance up to a point.

    Values are currently set in the code as follows:
     - **Min distance** (under this distance, error is never added): 50 (blocks/meters)
     - **Max distance** (the distance at which max error is added): 10000 (blocks/meters)
     - **Max error** (the max error added to each axis): ±2500 (blocks/meters)

    These values could/should probably be changed or added as configuration options.

    This PR also introduces a configuration option `enablePlayerPosRandomError` that enables or disables adding random error to the player's position. This configuration option is set to false by default to avoid a breaking change.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No. The feature introduced in this PR is disabled by default.

* **Other information**:
The numeric values in this change (such as min/max distance and max error) are currently hard-coded in the code and should probably be added to configuration.
Consider adding error to player yaw, pitch, and especially eyeHeight.