### PR TITLE
Added optional parameter to getPlayerPos to specify the amount of dec…

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -1,5 +1,6 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.peripheral;
 
+import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
@@ -193,7 +194,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
     }
 
     @LuaFunction(value = {"getPlayerPos", "getPlayer"}, mainThread = true)
-    public final Map<String, Object> getPlayerPos(String username) throws LuaException {
+    public final Map<String, Object> getPlayerPos(IArguments arguments) throws LuaException {
         if (!APConfig.PERIPHERALS_CONFIG.playerSpy.get())
             throw new LuaException("This function is disabled in the config. Activate it or ask an admin if he can activate it.");
         ResourceKey<Level> dimension = getLevel().dimension();
@@ -202,7 +203,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
         for (ServerPlayer player : getPlayers()) {
             if (!isAllowedMultiDimensional() && player.getLevel().dimension() != dimension)
                 continue;
-            if (player.getName().getString().equals(username)) {
+            if (player.getName().getString().equals(arguments.getString(0))) {
                 if (MAX_RANGE == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, MAX_RANGE, MAX_RANGE))
                     existingPlayer = player;
                 break;
@@ -247,9 +248,11 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
         }
 
-        info.put("x", Math.floor(x));
-        info.put("y", Math.floor(y));
-        info.put("z", Math.floor(z));
+        int decimals = Math.min(arguments.optInt(1, 0), 4);
+
+        info.put("x", Math.floor(x * Math.pow(10, decimals)) / Math.pow(10, decimals));
+        info.put("y", Math.floor(y * Math.pow(10, decimals)) / Math.pow(10, decimals));
+        info.put("z", Math.floor(z * Math.pow(10, decimals)) / Math.pow(10, decimals));
         if (APConfig.PERIPHERALS_CONFIG.morePlayerInformation.get()) {
             info.put("yaw", existingPlayer.yRotO);
             info.put("pitch", existingPlayer.xRotO);


### PR DESCRIPTION
…imal places to retrieve the position of

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
When using the getPlayerPos function the number of decimal places can be (optionally) entered after the player name, to make the retrieved position more precise (up to 4 places)

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/IntelligenceModding/Advanced-Peripherals-Features/issues/66

* **What is the new behavior (if this is a feature change)?**
No longer is the position limited to whole blocks accuracy

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No since the parameter is optional

* **Other information**:

