### PR TITLE
Backport [#487] Fixed ConcurrentModificationException when we try to add crafting jobs to the bridge while the bridge tries to manage the craft jobs

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/CraftJob.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/CraftJob.java
@@ -4,7 +4,6 @@ import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.*;
 import appeng.api.networking.security.IActionSource;
-import appeng.api.networking.storage.IStorageService;
 import appeng.api.stacks.AEKey;
 import dan200.computercraft.api.lua.ILuaCallback;
 import dan200.computercraft.api.lua.LuaException;
@@ -75,7 +74,6 @@ public class CraftJob implements ILuaCallback {
             return;
         }
 
-        IStorageService storage = grid.getService(IStorageService.class);
         ICraftingService crafting = grid.getService(ICraftingService.class);
 
         if (item == null) {
@@ -108,8 +106,6 @@ public class CraftJob implements ILuaCallback {
             return;
         }
 
-        setStartedCrafting(true);
-
         if (job.simulation()) {
             return;
         }
@@ -122,6 +118,8 @@ public class CraftJob implements ILuaCallback {
         //TODO: Create events or methods like `isCraftingFinished` or `getCraftingJobState`
         ICraftingService crafting = grid.getService(ICraftingService.class);
         crafting.submitJob(job, null, target, false, this.source);
+
+        setStartedCrafting(true);
 
         this.futureJob = null;
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/BeaconIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/BeaconIntegration.java
@@ -2,7 +2,6 @@ package de.srendi.advancedperipherals.common.addons.computercraft.integrations;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BeaconBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
…

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [X] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [ ] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)

This backports the fix for #487 to the 1.18 branch.

I ran into a similar error to the one described in #487, which appears to be fixed by this patch. Although, in my case, I only had a single computer, though it was probably trying to craft to many things too many times.