### PR TITLE
Fix meBridge.listCraftableItems and meBridge.listCraftableFluids to not be quadratic.

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -75,36 +75,46 @@ public class AppEngApi {
         return null;
     }
 
-    public static List<Object> listStacks(MEStorage monitor, ICraftingService service, int flag) {
+    public static List<Object> listStacks(MEStorage monitor, ICraftingService service) {
         List<Object> items = new ArrayList<>();
         KeyCounter keyCounter = monitor.getAvailableStacks();
         for (Object2LongMap.Entry<AEKey> aeKey : keyCounter) {
             if (aeKey.getKey() instanceof AEItemKey itemKey) {
-                if (flag == 1 && aeKey.getLongValue() < 0) {
-                    continue;
-                } else if (flag == 2 && !service.isCraftable(itemKey)) {
-                    service.getCraftables(AEKeyFilter.none()).forEach(aeKey1 -> {
-                        Map<String, Object> itemObject = getObjectFromStack(Pair.of((long) 0, aeKey1), service);
-                        if (keyCounter.get(aeKey1) == 0 && !items.contains(itemObject))
-                            items.add(itemObject);
-                    });
-                    continue;
-                }
-
                 items.add(getObjectFromStack(Pair.of(aeKey.getLongValue(), itemKey), service));
             }
         }
         return items;
     }
 
-    public static List<Object> listFluids(MEStorage monitor, ICraftingService service, int flag) {
+    public static List<Object> listCraftableStacks(MEStorage monitor, ICraftingService service) {
+        List<Object> items = new ArrayList<>();
+        KeyCounter keyCounter = monitor.getAvailableStacks();
+        Set<AEKey> craftables = service.getCraftables(AEKeyFilter.none());
+        for (AEKey aeKey : craftables) {
+            if (aeKey instanceof AEItemKey) {
+                items.add(getObjectFromStack(Pair.of(keyCounter.get(aeKey), aeKey), service));
+            }
+        }
+        return items;
+    }
+
+    public static List<Object> listFluids(MEStorage monitor, ICraftingService service) {
         List<Object> items = new ArrayList<>();
         for (Object2LongMap.Entry<AEKey> aeKey : monitor.getAvailableStacks()) {
             if (aeKey.getKey() instanceof AEFluidKey itemKey) {
-                if ((flag == 1 && aeKey.getLongValue() < 0) || (flag == 2 && !service.isCraftable(itemKey)))
-                    continue;
-
                 items.add(getObjectFromStack(Pair.of(aeKey.getLongValue(), itemKey), service));
+            }
+        }
+        return items;
+    }
+
+    public static List<Object> listCraftableFluids(MEStorage monitor, ICraftingService service) {
+        List<Object> items = new ArrayList<>();
+        KeyCounter keyCounter = monitor.getAvailableStacks();
+        Set<AEKey> craftables = service.getCraftables(AEKeyFilter.none());
+        for (AEKey aeKey : craftables) {
+            if (aeKey instanceof AEFluidKey) {
+                items.add(getObjectFromStack(Pair.of(keyCounter.get(aeKey), aeKey), service));
             }
         }
         return items;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MeBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MeBridgePeripheral.java
@@ -358,7 +358,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
         if (!isConnected())
             return notConnected();
 
-        return MethodResult.of(AppEngApi.listStacks(AppEngApi.getMonitor(node), getCraftingService(), 0));
+        return MethodResult.of(AppEngApi.listStacks(AppEngApi.getMonitor(node), getCraftingService()));
     }
 
     @LuaFunction(mainThread = true)
@@ -366,7 +366,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
         if (!isConnected())
             return notConnected();
 
-        return MethodResult.of(AppEngApi.listStacks(AppEngApi.getMonitor(node), getCraftingService(), 2));
+        return MethodResult.of(AppEngApi.listCraftableStacks(AppEngApi.getMonitor(node), getCraftingService()));
     }
 
     @LuaFunction(mainThread = true)
@@ -374,7 +374,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
         if (!isConnected())
             return notConnected();
 
-        return MethodResult.of(AppEngApi.listFluids(AppEngApi.getMonitor(node), getCraftingService(), 0));
+        return MethodResult.of(AppEngApi.listFluids(AppEngApi.getMonitor(node), getCraftingService()));
     }
 
     @LuaFunction(mainThread = true)
@@ -382,7 +382,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
         if (!isConnected())
             return notConnected();
 
-        return MethodResult.of(AppEngApi.listFluids(AppEngApi.getMonitor(node), getCraftingService(), 2));
+        return MethodResult.of(AppEngApi.listCraftableFluids(AppEngApi.getMonitor(node), getCraftingService()));
     }
 
     @LuaFunction(mainThread = true)


### PR DESCRIPTION
Applied Energistics will return the set of all craftable things. Iterate over that to generate the list of craftable things, instead of something more complicated.

Previously, the code would

1. Iterate over *every* item in the entire ME system.
2. For *each* non-craftable item, iterate over every craftable item and a) create the corresponding lua object b) if the craftable item isn't present in ME system, check if the list of objects to return contains that object (which requires sequentially scanning the list of objects to return.

This meant that

1. If there were no non-craftable items in the ME system, none of the craftable items that weren't present in the system would be returned.
2. The code was quadratic or cubic in runtime.

---


**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [X] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [ ] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)

This fixes a couple of bugs in listing craftable items/fluids in an ME system.


* **What is the current behavior?** (You can also link to an open issue here)

- Quadratic or cubic runtime for listing craftable items in an ME system.
- Not listing craftable items that are not in the ME system, if there are *no* non-craftable items in the system.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)

This might change the order of the list of craftable items returned.

* **Other information**:

This PR is against the 1.18 branch, since the modpack I am currently playing is a 1.18 modpack. I've not tested this change against newer versions.