### PR TITLE
Report the crafting CPU selection mode in `meBridge.getCraftingCPUs()`.

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -161,6 +161,7 @@ public class AppEngApi {
         map.put("coProcessors", coProcessors);
         map.put("isBusy", isBusy);
         map.put("craftingJob", cpu.getJobStatus() != null ? getObjectFromJob(cpu.getJobStatus()) : null);
+        map.put("selectionMode", cpu.getSelectionMode().toString());
 
         return map;
     }


### PR DESCRIPTION
This allows determining whether there are any available CPUs that can handle requests from automation. This is relevant if some crafting CPUs have been reserved for use by players.

---

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [X] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [ ] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)

Feature

* **What is the new behavior (if this is a feature change)?**

`meBridge.getCraftingCPUs()` returns objects with a new field `selectionMode` which can have one of `ANY`, `PLAYER_ONLY` or `MACHINE_ONLY`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)

No.

* **Other information**:

This PR is against the 1.18 branch, since the modpack I am currently playing is a 1.18 modpack. I've not tested this change against newer versions.