### PR TITLE
Generic peripherals

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlinx_coroutines_version=1.6.0-RC3
 ttoolkit_version=0.1.3
 
 # Mod dependencies
-cc_version=1.108.4
+cc_version=1.110.0
 curios_version=5.2.0+1.20.1
 minecolonies_version=1.20.1-1.1.472-BETA
 appliedenergistics_version=15.0.9-beta

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/APAddons.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/APAddons.java
@@ -40,9 +40,11 @@ public class APAddons {
 
     @SubscribeEvent
     public static void interModComms(InterModEnqueueEvent event) {
-        if (!curiosLoaded)
-            return;
+        /*
+        if (!curiosLoaded) {
+        }
 
-        // InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> new SlotTypeMessage.Builder("glasses").size(1).build());
+        InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> new SlotTypeMessage.Builder("glasses").size(1).build());
+        */
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -334,7 +334,7 @@ public class AppEngApi {
                         total += disk.getBytes(null);
                     }
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof SuperStorageCell superStorageCell)) {
-                    total += superStorageCell.getKiloBytes() * 1024;
+                    total += superStorageCell.getKiloBytes() * 1024L;
                 }
             }
         }
@@ -382,7 +382,7 @@ public class AppEngApi {
                         total += cell.getBytes(null);
                     }
                 } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof SuperStorageCell superStorageCell) {
-                    total += superStorageCell.getKiloBytes() * 1024;
+                    total += superStorageCell.getKiloBytes() * 1024L;
                 }
             }
         }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/Integration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/Integration.java
@@ -1,16 +1,13 @@
 package de.srendi.advancedperipherals.common.addons.botania;
 
-import de.srendi.advancedperipherals.common.addons.computercraft.integrations.IntegrationPeripheralProvider;
-import vazkii.botania.api.block_entity.GeneratingFlowerBlockEntity;
-import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
-import vazkii.botania.common.block.block_entity.mana.ManaSpreaderBlockEntity;
+import dan200.computercraft.api.ComputerCraftAPI;
 
 public class Integration implements Runnable {
 
     @Override
     public void run() {
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(ManaFlowerIntegration::new, GeneratingFlowerBlockEntity.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(ManaPoolIntegration::new, ManaPoolBlockEntity.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(SpreaderIntegration::new, ManaSpreaderBlockEntity.class);
+        ComputerCraftAPI.registerGenericSource(new ManaFlowerIntegration());
+        ComputerCraftAPI.registerGenericSource(new ManaPoolIntegration());
+        ComputerCraftAPI.registerGenericSource(new SpreaderIntegration());
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaFlowerIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaFlowerIntegration.java
@@ -1,50 +1,47 @@
 package de.srendi.advancedperipherals.common.addons.botania;
 
 import dan200.computercraft.api.lua.LuaFunction;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 import vazkii.botania.api.block_entity.GeneratingFlowerBlockEntity;
+import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
 
-public class ManaFlowerIntegration extends BlockEntityIntegrationPeripheral<GeneratingFlowerBlockEntity> {
+public class ManaFlowerIntegration implements APGenericPeripheral {
 
-    public ManaFlowerIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "manaFlower";
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isFloating() {
+    public final boolean isFloating(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.isFloating();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMaxMana() {
+    public final int getMaxMana(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.getMaxMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMana() {
+    public final int getMana(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.getMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isOnEnchantedSoil() {
+    public final boolean isOnEnchantedSoil(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.overgrowth;
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isFull() {
+    public final boolean isFull(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.getMana() >= blockEntity.getMaxMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isEmpty() {
+    public final boolean isEmpty(GeneratingFlowerBlockEntity blockEntity) {
         return blockEntity.getMana() == 0;
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaFlowerIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaFlowerIntegration.java
@@ -2,11 +2,7 @@ package de.srendi.advancedperipherals.common.addons.botania;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import vazkii.botania.api.block_entity.GeneratingFlowerBlockEntity;
-import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
 
 public class ManaFlowerIntegration implements APGenericPeripheral {
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaPoolIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaPoolIntegration.java
@@ -3,13 +3,10 @@ package de.srendi.advancedperipherals.common.addons.botania;
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
 import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
-import org.jetbrains.annotations.NotNull;
 import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
 
 import java.util.List;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaPoolIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/ManaPoolIntegration.java
@@ -2,6 +2,7 @@ package de.srendi.advancedperipherals.common.addons.botania;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -14,56 +15,51 @@ import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class ManaPoolIntegration extends BlockEntityIntegrationPeripheral<ManaPoolBlockEntity> {
+public class ManaPoolIntegration implements APGenericPeripheral {
 
-    public ManaPoolIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "manaPool";
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMana() {
+    public final int getMana(ManaPoolBlockEntity blockEntity) {
         return blockEntity.getCurrentMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMaxMana() {
+    public final int getMaxMana(ManaPoolBlockEntity blockEntity) {
         return blockEntity.getMaxMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getManaNeeded() {
+    public final int getManaNeeded(ManaPoolBlockEntity blockEntity) {
         return blockEntity.getAvailableSpaceForMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isFull() {
+    public final boolean isFull(ManaPoolBlockEntity blockEntity) {
         return blockEntity.isFull();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isEmpty() {
+    public final boolean isEmpty(ManaPoolBlockEntity blockEntity) {
         return blockEntity.getCurrentMana() == 0;
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean canChargeItem() {
+    public final boolean canChargeItem(ManaPoolBlockEntity blockEntity) {
         return blockEntity.isOutputtingPower();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean hasItems() {
-        return !getPoolItems().isEmpty();
+    public final boolean hasItems(ManaPoolBlockEntity blockEntity) {
+        return !getPoolItems(blockEntity).isEmpty();
     }
 
     @LuaFunction(mainThread = true)
-    public final Object getItems() {
-        List<ItemStack> items = getPoolItems();
+    public final Object getItems(ManaPoolBlockEntity blockEntity) {
+        List<ItemStack> items = getPoolItems(blockEntity);
         if(items.isEmpty())
             return null;
         Object[] luaStacks = new Object[items.size()];
@@ -75,7 +71,7 @@ public class ManaPoolIntegration extends BlockEntityIntegrationPeripheral<ManaPo
         return luaStacks;
     }
 
-    private List<ItemStack> getPoolItems() {
+    private List<ItemStack> getPoolItems(ManaPoolBlockEntity blockEntity) {
         BlockPos position = blockEntity.getBlockPos();
         return blockEntity.getLevel().getEntitiesOfClass(ItemEntity.class, new AABB(position, position.offset(1, 1, 1)))
                 .stream()

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/SpreaderIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/SpreaderIntegration.java
@@ -3,10 +3,7 @@ package de.srendi.advancedperipherals.common.addons.botania;
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
 import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import vazkii.botania.common.block.block_entity.mana.ManaSpreaderBlockEntity;
 
 public class SpreaderIntegration implements APGenericPeripheral {

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/botania/SpreaderIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/botania/SpreaderIntegration.java
@@ -2,62 +2,58 @@ package de.srendi.advancedperipherals.common.addons.botania;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 import vazkii.botania.common.block.block_entity.mana.ManaSpreaderBlockEntity;
 
-public class SpreaderIntegration extends BlockEntityIntegrationPeripheral<ManaSpreaderBlockEntity> {
+public class SpreaderIntegration implements APGenericPeripheral {
 
-    public SpreaderIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "manaSpreader";
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMana() {
+    public final int getMana(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.getCurrentMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMaxMana() {
+    public final int getMaxMana(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.getMaxMana();
     }
 
     @LuaFunction(mainThread = true)
-    public final Object getBounding() {
+    public final Object getBounding(ManaSpreaderBlockEntity blockEntity) {
         if (blockEntity.getBinding() == null) return null;
         return LuaConverter.posToObject(blockEntity.getBinding());
     }
 
     @LuaFunction(mainThread = true)
-    public final String getVariant() {
+    public final String getVariant(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.getVariant().toString();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isFull() {
+    public final boolean isFull(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.isFull();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isEmpty() {
+    public final boolean isEmpty(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.getCurrentMana() == 0;
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean hasLens() {
+    public final boolean hasLens(ManaSpreaderBlockEntity blockEntity) {
         return blockEntity.getItem(0) != ItemStack.EMPTY;
     }
 
     @LuaFunction(mainThread = true)
-    public final Object getLens() {
+    public final Object getLens(ManaSpreaderBlockEntity blockEntity) {
         if(blockEntity.getItem(0) == ItemStack.EMPTY)
             return null;
         return LuaConverter.stackToObject(blockEntity.getItem(0));

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/BeaconIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/BeaconIntegration.java
@@ -1,37 +1,30 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.integrations;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BeaconBlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 
-public class BeaconIntegration extends BlockEntityIntegrationPeripheral<BeaconBlockEntity> {
-
-    public BeaconIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
+public class BeaconIntegration implements APGenericPeripheral {
     @Override
-    public @NotNull String getType() {
+    public String getPeripheralType() {
         return "beacon";
     }
 
     @LuaFunction(mainThread = true)
-    public final int getLevel() {
+    public final int getLevel(BeaconBlockEntity blockEntity) {
         // because levels are now protected field .... why?
         CompoundTag savedData = blockEntity.saveWithoutMetadata();
         return savedData.getInt("Levels");
     }
 
     @LuaFunction(mainThread = true)
-    public final String getPrimaryEffect() {
+    public final String getPrimaryEffect(BeaconBlockEntity blockEntity) {
         return blockEntity.primaryPower == null ? "none" : blockEntity.primaryPower.getDescriptionId();
     }
 
     @LuaFunction(mainThread = true)
-    public final String getSecondaryEffect() {
+    public final String getSecondaryEffect(BeaconBlockEntity blockEntity) {
         return blockEntity.secondaryPower == null ? "none" : blockEntity.secondaryPower.getDescriptionId();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
@@ -37,7 +37,10 @@ public class IntegrationPeripheralProvider implements IPeripheralProvider {
      * @param integration integration generator
      * @param tileClass   target integration class
      * @param <T>         target integration
+     *
+     * @deprecated will be removed in 1.21. Use generics instead, see existing integrations
      */
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.39")
     public static <T extends BlockEntity> void registerBlockEntityIntegration(Function<BlockEntity, BlockEntityIntegrationPeripheral<T>> integration, Class<T> tileClass) {
         registerIntegration(new BlockEntityIntegration(integration, tileClass::isInstance));
     }
@@ -49,7 +52,10 @@ public class IntegrationPeripheralProvider implements IPeripheralProvider {
      * @param tileClass   target integration class
      * @param priority    Integration priority, lower is better
      * @param <T>         target integration
+     *
+     * @deprecated will be removed in 1.21. Use generics instead, see existing integrations
      */
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.39")
     public static <T extends BlockEntity> void registerBlockEntityIntegration(Function<BlockEntity, BlockEntityIntegrationPeripheral<T>> integration, Class<T> tileClass, int priority) {
         registerIntegration(new BlockEntityIntegration(integration, tileClass::isInstance, priority));
     }
@@ -63,7 +69,10 @@ public class IntegrationPeripheralProvider implements IPeripheralProvider {
      * @param predicate   target block entity
      * @param priority    Integration priority, lower is better
      * @param <T>         target integration
+     *
+     * @deprecated will be removed in 1.21. Use generics instead, see existing integrations
      */
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.39")
     public static <T extends BlockEntity> void registerBlockEntityIntegration(Function<BlockEntity, BlockEntityIntegrationPeripheral<T>> integration, Class<T> tileClass, Predicate<T> predicate, int priority) {
         registerIntegration(new BlockEntityIntegration(integration, tile -> tileClass.isInstance(tile) && predicate.test((T) tile), priority));
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/integrations/IntegrationPeripheralProvider.java
@@ -1,5 +1,6 @@
 package de.srendi.advancedperipherals.common.addons.computercraft.integrations;
 
+import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
@@ -10,7 +11,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.NoteBlock;
-import net.minecraft.world.level.block.entity.BeaconBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
@@ -70,7 +70,7 @@ public class IntegrationPeripheralProvider implements IPeripheralProvider {
     }
 
     public static void load() {
-        registerIntegration(new BlockEntityIntegration(BeaconIntegration::new, BeaconBlockEntity.class::isInstance));
+        ComputerCraftAPI.registerGenericSource(new BeaconIntegration());
         registerIntegration(new BlockIntegration(NoteBlockIntegration::new, NoteBlock.class::isInstance));
 
         for (String mod : SUPPORTED_MODS) {

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/BasinIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/BasinIntegration.java
@@ -27,9 +27,9 @@ public class BasinIntegration implements APGenericPeripheral {
     @LuaFunction(mainThread = true)
     public final List<Object> getInputFluids(BasinBlockEntity blockEntity) {
         IFluidHandler handler = blockEntity.getTanks().getFirst().getCapability().orElse(null);
-        if (handler == null) {
+        if (handler == null)
             return null;
-        }
+
         int size = handler.getTanks();
         List<Object> tanks = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/BasinIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/BasinIntegration.java
@@ -3,13 +3,12 @@ package de.srendi.advancedperipherals.common.addons.create;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import dan200.computercraft.api.lua.LuaFunction;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -18,20 +17,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class BasinIntegration extends BlockEntityIntegrationPeripheral<BasinBlockEntity> {
-
-    public BasinIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
+public class BasinIntegration implements APGenericPeripheral {
     @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "basin";
     }
 
     @LuaFunction(mainThread = true)
-    public final List<Object> getInputFluids() {
+    public final List<Object> getInputFluids(BasinBlockEntity blockEntity) {
         IFluidHandler handler = blockEntity.getTanks().getFirst().getCapability().orElse(null);
         if (handler == null) {
             return null;
@@ -49,7 +43,7 @@ public class BasinIntegration extends BlockEntityIntegrationPeripheral<BasinBloc
     }
 
     @LuaFunction(mainThread = true)
-    public final List<Object> getOutputFluids() {
+    public final List<Object> getOutputFluids(BasinBlockEntity blockEntity) {
         IFluidHandler handler = blockEntity.getTanks().getSecond().getCapability().orElse(null);
         if (handler == null) {
             return null;
@@ -67,12 +61,12 @@ public class BasinIntegration extends BlockEntityIntegrationPeripheral<BasinBloc
     }
 
     @LuaFunction(mainThread = true)
-    public final Map<String, Object> getFilter() {
+    public final Map<String, Object> getFilter(BasinBlockEntity blockEntity) {
         return LuaConverter.stackToObject(blockEntity.getFilter().getFilter());
     }
 
     @LuaFunction(mainThread = true)
-    public final List<Object> getInventory() {
+    public final List<Object> getInventory(BasinBlockEntity blockEntity) {
         Optional<IItemHandler> handlerOptional = blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER).resolve();
         if (handlerOptional.isEmpty()) return null;
         IItemHandler handler = handlerOptional.get();

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/BlazeBurnerIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/BlazeBurnerIntegration.java
@@ -2,27 +2,21 @@ package de.srendi.advancedperipherals.common.addons.create;
 
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlockEntity;
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class BlazeBurnerIntegration extends BlockEntityIntegrationPeripheral<BlazeBurnerBlockEntity> {
-
-    public BlazeBurnerIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
+public class BlazeBurnerIntegration implements APGenericPeripheral {
     @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "blazeBurner";
     }
 
     @LuaFunction(mainThread = true)
-    public final Map<String, Object> getInfo() {
+    public final Map<String, Object> getInfo(BlazeBurnerBlockEntity blockEntity) {
         Map<String, Object> data = new HashMap<>();
         data.put("fuelType", blockEntity.getActiveFuel().toString().toLowerCase());
         data.put("heatLevel", blockEntity.getHeatLevelFromBlock().getSerializedName());

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/FluidTankIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/FluidTankIntegration.java
@@ -2,28 +2,22 @@ package de.srendi.advancedperipherals.common.addons.create;
 
 import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class FluidTankIntegration extends BlockEntityIntegrationPeripheral<FluidTankBlockEntity> {
-
-    public FluidTankIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
+public class FluidTankIntegration implements APGenericPeripheral {
     @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "fluidTank";
     }
 
     @LuaFunction(mainThread = true)
-    public final Map<String, Object> getInfo() {
+    public final Map<String, Object> getInfo(FluidTankBlockEntity blockEntity) {
         Map<String, Object> data = new HashMap<>();
         data.put("capacity", blockEntity.getControllerBE().getTankInventory().getCapacity());
         data.put("amount", blockEntity.getControllerBE().getTankInventory().getFluidAmount());

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/Integration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/Integration.java
@@ -1,20 +1,16 @@
 package de.srendi.advancedperipherals.common.addons.create;
 
-import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
-import com.simibubi.create.content.kinetics.mixer.MechanicalMixerBlockEntity;
-import com.simibubi.create.content.processing.basin.BasinBlockEntity;
-import com.simibubi.create.content.processing.burner.BlazeBurnerBlockEntity;
-import de.srendi.advancedperipherals.common.addons.computercraft.integrations.IntegrationPeripheralProvider;
+import dan200.computercraft.api.ComputerCraftAPI;
 
 public class Integration implements Runnable {
 
     @Override
     public void run() {
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(BlazeBurnerIntegration::new, BlazeBurnerBlockEntity.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(FluidTankIntegration::new, FluidTankBlockEntity.class);
+        ComputerCraftAPI.registerGenericSource(new BlazeBurnerIntegration());
+        ComputerCraftAPI.registerGenericSource(new FluidTankIntegration());
         // Disable until verified that it does not clash with the existing create CC integration
         //IntegrationPeripheralProvider.registerBlockEntityIntegration(ScrollValueBehaviourIntegration::new, KineticTileEntity.class, tile -> tile.getBehaviour(ScrollValueBehaviour.TYPE) != null, 10);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(BasinIntegration::new, BasinBlockEntity.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(MechanicalMixerIntegration::new, MechanicalMixerBlockEntity.class);
+        ComputerCraftAPI.registerGenericSource(new BasinIntegration());
+        ComputerCraftAPI.registerGenericSource(new MechanicalMixerIntegration());
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/create/MechanicalMixerIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/create/MechanicalMixerIntegration.java
@@ -3,29 +3,24 @@ package de.srendi.advancedperipherals.common.addons.create;
 import com.simibubi.create.content.kinetics.mixer.MechanicalMixerBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 
-public class MechanicalMixerIntegration extends BlockEntityIntegrationPeripheral<MechanicalMixerBlockEntity> {
-
-    public MechanicalMixerIntegration(BlockEntity entity) {
-        super(entity);
-    }
-
+public class MechanicalMixerIntegration implements APGenericPeripheral {
     @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "mechanicalMixer";
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isRunning() {
+    public final boolean isRunning(MechanicalMixerBlockEntity blockEntity) {
         return blockEntity.running;
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean hasBasin() {
+    public final boolean hasBasin(MechanicalMixerBlockEntity blockEntity) {
         if (blockEntity.getLevel() == null) return false;
         BlockEntity basinTE = blockEntity.getLevel().getBlockEntity(blockEntity.getBlockPos().below(2));
         return basinTE instanceof BasinBlockEntity;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
@@ -1,53 +1,42 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import owmii.powah.block.ender.EnderCellTile;
 
-public class EnderCellIntegration extends BlockEntityIntegrationPeripheral<EnderCellTile> {
-    protected EnderCellIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class EnderCellIntegration implements APGenericPeripheral {
 
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "enderCell";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
-        return "Ender Cell";
-    }
-
-    @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(EnderCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(EnderCellTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final int getChannel() {
+    public final int getChannel(EnderCellTile blockEntity) {
         // Lua, and generally slots in MC, seem to be 1 based, make the conversion here
         int channel = blockEntity.getChannel().get();
         return channel + 1;
     }
 
     @LuaFunction(mainThread = true)
-    public final void setChannel(int channel) {
+    public final void setChannel(EnderCellTile blockEntity, int channel) {
         // Lua, and generally slots in MC, seem to be 1 based, make the conversion here
         channel = channel - 1;
         blockEntity.getChannel().set(channel);
     }
 
     @LuaFunction(mainThread = true)
-    public final int getMaxChannels() {
+    public final int getMaxChannels(EnderCellTile blockEntity) {
         return blockEntity.getMaxChannels();
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
@@ -1,19 +1,13 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import owmii.powah.block.energycell.EnergyCellTile;
 
-public class EnergyCellIntegration extends BlockEntityIntegrationPeripheral<EnergyCellTile> {
-    protected EnergyCellIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class EnergyCellIntegration implements APGenericPeripheral {
 
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "energyCell";
     }
 
@@ -23,12 +17,12 @@ public class EnergyCellIntegration extends BlockEntityIntegrationPeripheral<Ener
     }
 
     @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(EnergyCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(EnergyCellTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/FurnatorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/FurnatorIntegration.java
@@ -1,50 +1,39 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import owmii.powah.block.furnator.FurnatorTile;
 
-public class FurnatorIntegration extends BlockEntityIntegrationPeripheral<FurnatorTile> {
-    protected FurnatorIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class FurnatorIntegration implements APGenericPeripheral {
 
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "furnator";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
-        return "Furnator";
-    }
-
-    @LuaFunction(mainThread = true)
-    public final boolean isBurning() {
+    public final boolean isBurning(FurnatorTile blockEntity) {
         return blockEntity.isBurning();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(FurnatorTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(FurnatorTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getCarbon() {
+    public final double getCarbon(FurnatorTile blockEntity) {
         return blockEntity.getCarbon().perCent();
     }
 
     @LuaFunction(mainThread = true)
-    public final ItemStack getInventory() {
+    public final ItemStack getInventory(FurnatorTile blockEntity) {
         return blockEntity.getInventory().getStackInSlot(1);
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/Integration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/Integration.java
@@ -1,23 +1,17 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
-import de.srendi.advancedperipherals.common.addons.computercraft.integrations.IntegrationPeripheralProvider;
-import owmii.powah.block.energycell.EnergyCellTile;
-import owmii.powah.block.ender.EnderCellTile;
-import owmii.powah.block.furnator.FurnatorTile;
-import owmii.powah.block.magmator.MagmatorTile;
-import owmii.powah.block.reactor.ReactorPartTile;
-import owmii.powah.block.solar.SolarTile;
-import owmii.powah.block.thermo.ThermoTile;
+import dan200.computercraft.api.ComputerCraftAPI;
 
 public class Integration implements Runnable {
+
     @Override
     public void run() {
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(ReactorIntegration::new, ReactorPartTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(EnergyCellIntegration::new, EnergyCellTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(EnderCellIntegration::new, EnderCellTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(SolarPanelIntegration::new, SolarTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(FurnatorIntegration::new, FurnatorTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(MagmatorIntegration::new, MagmatorTile.class);
-        IntegrationPeripheralProvider.registerBlockEntityIntegration(ThermoIntegration::new, ThermoTile.class);
+        ComputerCraftAPI.registerGenericSource(new ReactorIntegration());
+        ComputerCraftAPI.registerGenericSource(new EnergyCellIntegration());
+        ComputerCraftAPI.registerGenericSource(new EnderCellIntegration());
+        ComputerCraftAPI.registerGenericSource(new SolarPanelIntegration());
+        ComputerCraftAPI.registerGenericSource(new FurnatorIntegration());
+        ComputerCraftAPI.registerGenericSource(new MagmatorIntegration());
+        ComputerCraftAPI.registerGenericSource(new ThermoIntegration());
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/MagmatorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/MagmatorIntegration.java
@@ -1,49 +1,40 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import org.jetbrains.annotations.NotNull;
 import owmii.powah.block.magmator.MagmatorTile;
 
-public class MagmatorIntegration extends BlockEntityIntegrationPeripheral<MagmatorTile> {
-    protected MagmatorIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class MagmatorIntegration implements APGenericPeripheral {
 
     @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "magmator";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
-        return "Magmator";
-    }
-
-    @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(MagmatorTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(MagmatorTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean isBurning() {
+    public final boolean isBurning(MagmatorTile blockEntity) {
         return blockEntity.isBurning();
     }
 
     @LuaFunction(mainThread = true)
-    public final long getTankCapacity() {
+    public final long getTankCapacity(MagmatorTile blockEntity) {
         return blockEntity.getTank().getCapacity();
     }
 
     @LuaFunction(mainThread = true)
-    public final long getFluidInTank() {
+    public final long getFluidInTank(MagmatorTile blockEntity) {
         return blockEntity.getTank().getFluidAmount();
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ReactorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ReactorIntegration.java
@@ -1,93 +1,82 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import owmii.powah.block.reactor.ReactorPartTile;
 
-public class ReactorIntegration extends BlockEntityIntegrationPeripheral<ReactorPartTile> {
-    protected ReactorIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class ReactorIntegration implements APGenericPeripheral {
 
     @Override
-    @NotNull
-    public String getType() {
+    public String getPeripheralType() {
         return "uraniniteReactor";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
-        return "Uraninite Reactor";
-    }
-
-    @LuaFunction(mainThread = true)
-    public final boolean isRunning() {
+    public final boolean isRunning(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return false;
         return blockEntity.core().get().isRunning();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getFuel() {
+    public final double getFuel(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().fuel.perCent();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getCarbon() {
+    public final double getCarbon(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().carbon.perCent();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getRedstone() {
+    public final double getRedstone(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().redstone.perCent();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getTemperature() {
+    public final double getTemperature(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().temp.perCent();
     }
 
     @LuaFunction(mainThread = true)
-    public final ItemStack getInventoryUraninite() {
+    public final ItemStack getInventoryUraninite(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return ItemStack.EMPTY;
         return blockEntity.core().get().getInventory().getStackInSlot(1);
     }
 
     @LuaFunction(mainThread = true)
-    public final ItemStack getInventoryRedstone() {
+    public final ItemStack getInventoryRedstone(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return ItemStack.EMPTY;
         return blockEntity.core().get().getInventory().getStackInSlot(3);
     }
 
     @LuaFunction(mainThread = true)
-    public final ItemStack getInventoryCarbon() {
+    public final ItemStack getInventoryCarbon(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return ItemStack.EMPTY;
         return blockEntity.core().get().getInventory().getStackInSlot(2);

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/SolarPanelIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/SolarPanelIntegration.java
@@ -1,39 +1,33 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import owmii.powah.block.solar.SolarTile;
 
-public class SolarPanelIntegration extends BlockEntityIntegrationPeripheral<SolarTile> {
-    protected SolarPanelIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class SolarPanelIntegration implements APGenericPeripheral {
 
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "solarPanel";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
+    public final String getName(SolarTile blockEntity) {
         return "Solar Panel";
     }
 
     @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(SolarTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(SolarTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final boolean canSeeSky() {
+    public final boolean canSeeSky(SolarTile blockEntity) {
         return blockEntity.canSeeSky();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ThermoIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ThermoIntegration.java
@@ -1,39 +1,33 @@
 package de.srendi.advancedperipherals.common.addons.powah;
 
 import dan200.computercraft.api.lua.LuaFunction;
-import de.srendi.advancedperipherals.lib.peripherals.BlockEntityIntegrationPeripheral;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
+import de.srendi.advancedperipherals.lib.peripherals.APGenericPeripheral;
 import owmii.powah.block.thermo.ThermoTile;
 
-public class ThermoIntegration extends BlockEntityIntegrationPeripheral<ThermoTile> {
-    protected ThermoIntegration(BlockEntity entity) {
-        super(entity);
-    }
+public class ThermoIntegration implements APGenericPeripheral {
 
-    @NotNull
     @Override
-    public String getType() {
+    public String getPeripheralType() {
         return "thermo";
     }
 
     @LuaFunction(mainThread = true)
-    public final String getName() {
+    public final String getName(ThermoTile blockEntity) {
         return "Thermo generator";
     }
 
     @LuaFunction(mainThread = true)
-    public final double getEnergy() {
+    public final double getEnergy(ThermoTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getMaxEnergy() {
+    public final double getMaxEnergy(ThermoTile blockEntity) {
         return blockEntity.getEnergy().getMaxEnergyStored();
     }
 
     @LuaFunction(mainThread = true)
-    public final double getCoolantInTank() {
+    public final double getCoolantInTank(ThermoTile blockEntity) {
         return blockEntity.getTank().getFluidAmount();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/lib/peripherals/APGenericPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/lib/peripherals/APGenericPeripheral.java
@@ -1,0 +1,19 @@
+package de.srendi.advancedperipherals.lib.peripherals;
+
+import dan200.computercraft.api.peripheral.GenericPeripheral;
+import dan200.computercraft.api.peripheral.PeripheralType;
+import de.srendi.advancedperipherals.AdvancedPeripherals;
+
+public interface APGenericPeripheral extends GenericPeripheral {
+    String getPeripheralType();
+
+    @Override
+    default String id() {
+        return AdvancedPeripherals.MOD_ID + ":" + getPeripheralType();
+    }
+
+    @Override
+    default PeripheralType getType() {
+        return PeripheralType.ofType(getPeripheralType());
+    }
+}


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


### **Please check if the PR fulfills these requirements**
- [ ] **The commit message are well described:** Not really, no!
- [x] All changes have fully been tested.

### **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Bug fix.

### **What is the current behavior?** (You can also link to an open issue here)
AdvancedPeripherals integrations override CC:T's generic peripherals. For instance, Create's fluid tanks no longer have a method to push/pull fluids.

### **What is the new behavior (if this is a feature change)?**
This migrates the vanilla and create peripherals to use the generic peripheral system.

![A screenshot of a computer's UI, with Lua code calling getInfo on a Create fluid tank.](https://github.com/IntelligenceModding/AdvancedPeripherals/assets/4346137/69ebfa20-8ed1-4743-9b52-e9552e2aced4)

### **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No breaking change change.

### **Other information**:
The Powah integration probably should be updated too, these two just seemed the easiest to demonstrate the change with.