### PR TITLE
Specify content filters for each maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,10 @@ repositories {
     maven {
         name = "Blamejared maven botania patchouli"
         url = 'https://maven.blamejared.com'
+        content {
+            includeGroup("vazkii.botania")
+            includeGroup("vazkii.patchouli")
+        }
     }
     maven {
         name = "Squiddev maven cct"
@@ -178,6 +182,9 @@ repositories {
     maven {
         name = "Theillusivec4 maven curios"
         url = "https://maven.theillusivec4.top/"
+        content {
+            includeGroup("top.theillusivec4.curios")
+        }
     }
     maven {
         name = "LDT Team minecolonies"
@@ -189,6 +196,11 @@ repositories {
     maven {
         name = "Modmaven Jei"
         url = 'https://modmaven.dev/'
+        content {
+            includeGroup("mezz.jei")
+            includeGroup("appeng")
+            includeGroup("mekanism")
+        }
     }
     maven {
         name = "Create maven"
@@ -196,6 +208,7 @@ repositories {
         content {
             includeGroup("com.simibubi.create")
             includeGroup("com.jozufozu.flywheel")
+            includeGroup("com.tterrag.registrate")
         }
     }
     maven {
@@ -208,6 +221,10 @@ repositories {
     maven {
         name = "Shedaniel cloth"
         url = "https://maven.shedaniel.me/"
+        content {
+            includeGroup("dev.architectury")
+            includeGroup("me.shedaniel.cloth")
+        }
     }
     maven {
         url = uri("https://maven.pkg.github.com/refinedmods/refinedstorage")
@@ -215,20 +232,22 @@ repositories {
             username = "anything"
             password = "\u0067hp_oGjcDFCn8jeTzIj4Ke9pLoEVtpnZMP4VQgaX"
         }
+        content {
+            includeModule("com.refinedmods", "refinedstorage")
+        }
     }
     maven {
         name = 'Kotlin for Forge'
         url = 'https://thedarkcolour.github.io/KotlinForForge/'
+        content {
+            includeModule("thedarkcolour", "kotlinforforge")
+        }
     }
     maven {
         url = "https://cursemaven.com"
         content {
             includeGroup "curse.maven"
         }
-    }
-    maven {
-        name = "Intelligence repository"
-        url = "https://mvn.intelligence-modding.de/Intelligence"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,10 +5,14 @@ pluginManagement {
         maven {
             name = 'NeoForged'
             url = 'https://maven.neoforged.net/releases'
-        }
-        maven {
-            name = "Intelligence Minecraft"
-            url = "https://mvn.intelligence-modding.de/Minecraft"
+
+            content {
+                includeGroup("net.minecraftforge")
+                includeGroup("net.neoforged.gradle")
+                includeGroup("net.neoforged")
+                includeGroup("org.spongepowered.mixin")
+                includeGroup("org.spongepowered")
+            }
         }
     }
 }


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


### **Please check if the PR fulfills these requirements**
- [ ] The commit message are well described
- [x] All changes have fully been tested

### **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Bug fix.

### **What is the current behaviour?** (You can also link to an open issue here)
A Gradle build with a clean cache can take a long time, as Gradle attempts to fetch every dependency from every Maven server. Yesterday I was having some connectivity issues to mvn.intelligence-modding.de, which caused just downloading Forge to take 10 minutes (let alone any of the mod dependencies)!

### **What is the new behaviour (if this is a feature change)?**
This now adds content filters to all of the additional repos, meaning Gradle will now only try to download from:

 - Maven Central
 - NeoForged's repo
 - The specific repo where the dependency is located.

We could prevent searching Maven Central and NeoForge by using [`exclusiveContent`](https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository) ([example in Mekanism](https://github.com/mekanism/Mekanism/blob/c65a64b9eba5be09d826bdebbeec6dd2b4d9efb2/build.gradle#L377-L402)), but that's a bit of a bigger change