### PR TITLE
fix: ME Bridge: Add support for child classes created by other mods

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -339,7 +339,7 @@ public class AppEngApi {
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
                     if (storageCell.getKeyType() != AEKeyType.items())
                         continue;
-                    total += storageCell.getKiloBytes() * 1024;
+                    total += storageCell.getKiloBytes() * 1024L;
                 }
             }
         }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -310,11 +310,11 @@ public class AppEngApi {
     public static long getTotalItemStorage(IGridNode node) {
         long total = 0;
 
-        Iterator<IGridNode> iterator = node.getGrid().getMachineNodes(DriveBlockEntity.class).iterator();
+        // note: do not query DriveBlockEntity.class specifically here, because it will avoid subclasses, e.g. the ME Extended Drive from ExtendedAE
+        Iterator<IGridNode> iterator = node.getGrid().getNodes().iterator();
 
         while (iterator.hasNext()) {
-            DriveBlockEntity entity = (DriveBlockEntity) iterator.next().getService(IStorageProvider.class);
-            if (entity == null)
+            if (!(iterator.next().getService(IStorageProvider.class) instanceof DriveBlockEntity entity))
                 continue;
 
             InternalInventory inventory = entity.getInternalInventory();
@@ -362,11 +362,10 @@ public class AppEngApi {
     public static long getTotalFluidStorage(IGridNode node) {
         long total = 0;
 
-        Iterator<IGridNode> iterator = node.getGrid().getMachineNodes(DriveBlockEntity.class).iterator();
+        Iterator<IGridNode> iterator = node.getGrid().getNodes().iterator();
 
         while (iterator.hasNext()) {
-            DriveBlockEntity entity = (DriveBlockEntity) iterator.next().getService(IStorageProvider.class);
-            if (entity == null)
+            if (!(iterator.next().getService(IStorageProvider.class) instanceof DriveBlockEntity entity))
                 continue;
 
             InternalInventory inventory = entity.getInternalInventory();
@@ -410,11 +409,10 @@ public class AppEngApi {
     public static long getUsedItemStorage(IGridNode node) {
         long used = 0;
 
-        Iterator<IGridNode> iterator = node.getGrid().getMachineNodes(DriveBlockEntity.class).iterator();
+        Iterator<IGridNode> iterator = node.getGrid().getNodes().iterator();
 
         while (iterator.hasNext()) {
-            DriveBlockEntity entity = (DriveBlockEntity) iterator.next().getService(IStorageProvider.class);
-            if (entity == null)
+            if (!(iterator.next().getService(IStorageProvider.class) instanceof DriveBlockEntity entity))
                 continue;
 
             InternalInventory inventory = entity.getInternalInventory();
@@ -472,11 +470,10 @@ public class AppEngApi {
     public static long getUsedFluidStorage(IGridNode node) {
         long used = 0;
 
-        Iterator<IGridNode> iterator = node.getGrid().getMachineNodes(DriveBlockEntity.class).iterator();
+        Iterator<IGridNode> iterator = node.getGrid().getNodes().iterator();
 
         while (iterator.hasNext()) {
-            DriveBlockEntity entity = (DriveBlockEntity) iterator.next().getService(IStorageProvider.class);
-            if (entity == null)
+            if (!(iterator.next().getService(IStorageProvider.class) instanceof DriveBlockEntity entity))
                 continue;
 
             InternalInventory inventory = entity.getInternalInventory();

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -337,6 +337,8 @@ public class AppEngApi {
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof SuperStorageCell superStorageCell)) {
                     total += superStorageCell.getKiloBytes() * 1024;
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
+                    if (storageCell.getKeyType() != AEKeyType.items())
+                        continue;
                     total += storageCell.getKiloBytes() * 1024;
                 }
             }
@@ -386,6 +388,8 @@ public class AppEngApi {
                 } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof SuperStorageCell superStorageCell) {
                     total += superStorageCell.getKiloBytes() * 1024;
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
+                    if (storageCell.getKeyType() != AEKeyType.fluids())
+                        continue;
                     total += storageCell.getKiloBytes() * 1024;
                 }
             }
@@ -452,7 +456,9 @@ public class AppEngApi {
                     long numItemsInCell = stack.getTag().getLong("ic");
 
                     used += numItemsInCell;
-                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell) {
+                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell storageCell) {
+                    if (storageCell.getKeyType() != AEKeyType.items())
+                        continue;
                     if (stack.getTag() == null)
                         continue;
                     long numItemsInCell = stack.getTag().getLong("ic");
@@ -509,7 +515,9 @@ public class AppEngApi {
                     long numItemsInCell = stack.getTag().getLong("ic");
 
                     used += numItemsInCell;
-                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell) {
+                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell storageCell) {
+                    if (storageCell.getKeyType() != AEKeyType.fluids())
+                        continue;
                     if (stack.getTag() == null)
                         continue;
                     long numItemsInCell = stack.getTag().getLong("ic");

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -339,7 +339,7 @@ public class AppEngApi {
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
                     if (storageCell.getKeyType() != AEKeyType.items())
                         continue;
-                    total += storageCell.getKiloBytes() * 1024;
+                    total += storageCell.getKiloBytes() * 1024L;
                 }
             }
         }
@@ -390,7 +390,7 @@ public class AppEngApi {
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
                     if (storageCell.getKeyType() != AEKeyType.fluids())
                         continue;
-                    total += storageCell.getKiloBytes() * 1024;
+                    total += storageCell.getKiloBytes() * 1024L;
                 }
             }
         }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -10,6 +10,7 @@ import appeng.api.stacks.*;
 import appeng.api.storage.AEKeyFilter;
 import appeng.api.storage.IStorageProvider;
 import appeng.api.storage.MEStorage;
+import appeng.api.storage.cells.IBasicCellItem;
 import appeng.blockentity.storage.DriveBlockEntity;
 import appeng.items.storage.BasicStorageCell;
 import appeng.parts.storagebus.StorageBusPart;
@@ -325,7 +326,7 @@ public class AppEngApi {
                 if (stack.isEmpty())
                     continue;
 
-                if (stack.getItem() instanceof BasicStorageCell cell) {
+                if (stack.getItem() instanceof IBasicCellItem cell) {
                     if (cell.getKeyType().getClass().isAssignableFrom(AEKeyType.items().getClass())) {
                         total += cell.getBytes(null);
                     }
@@ -377,7 +378,7 @@ public class AppEngApi {
                 if (stack.isEmpty())
                     continue;
 
-                if (stack.getItem() instanceof BasicStorageCell cell) {
+                if (stack.getItem() instanceof IBasicCellItem cell) {
                     if (cell.getKeyType().getClass().isAssignableFrom(AEKeyType.fluids().getClass())) {
                         total += cell.getBytes(null);
                     }
@@ -425,7 +426,7 @@ public class AppEngApi {
                 if (stack.isEmpty())
                     continue;
 
-                if (stack.getItem() instanceof BasicStorageCell cell) {
+                if (stack.getItem() instanceof IBasicCellItem cell) {
                     int bytesPerType = cell.getBytesPerType(null);
 
                     if (cell.getKeyType().getClass().isAssignableFrom(AEKeyType.items().getClass())) {
@@ -484,7 +485,7 @@ public class AppEngApi {
             for (int i = 0; i < inventory.size(); i++) {
                 ItemStack stack = inventory.getStackInSlot(i);
 
-                if (stack.getItem() instanceof BasicStorageCell cell) {
+                if (stack.getItem() instanceof IBasicCellItem cell) {
                     int bytesPerType = cell.getBytesPerType(null);
 
                     if (cell.getKeyType().getClass().isAssignableFrom(AEKeyType.fluids().getClass())) {

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -12,7 +12,6 @@ import appeng.api.storage.IStorageProvider;
 import appeng.api.storage.MEStorage;
 import appeng.api.storage.cells.IBasicCellItem;
 import appeng.blockentity.storage.DriveBlockEntity;
-import appeng.items.storage.BasicStorageCell;
 import appeng.parts.storagebus.StorageBusPart;
 import com.the9grounds.aeadditions.item.storage.SuperStorageCell;
 import dan200.computercraft.shared.util.NBTUtil;
@@ -549,7 +548,7 @@ public class AppEngApi {
                 if (stack.isEmpty())
                     continue;
 
-                if (stack.getItem() instanceof BasicStorageCell cell) {
+                if (stack.getItem() instanceof IBasicCellItem cell) {
                     items.add(getObjectFromCell(cell, stack));
                 } else if (APAddons.aeThingsLoaded && stack.getItem() instanceof DISKDrive disk) {
                     items.add(getObjectFromDisk(disk, stack));
@@ -562,7 +561,7 @@ public class AppEngApi {
         return items;
     }
 
-    private static Map<String, Object> getObjectFromCell(BasicStorageCell cell, ItemStack stack) {
+    private static Map<String, Object> getObjectFromCell(IBasicCellItem cell, ItemStack stack) {
         Map<String, Object> map = new HashMap<>();
 
         map.put("item", ItemUtil.getRegistryKey(stack.getItem()).toString());

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AppEngApi.java
@@ -13,6 +13,7 @@ import appeng.api.storage.MEStorage;
 import appeng.api.storage.cells.IBasicCellItem;
 import appeng.blockentity.storage.DriveBlockEntity;
 import appeng.parts.storagebus.StorageBusPart;
+import com.the9grounds.aeadditions.item.storage.StorageCell;
 import com.the9grounds.aeadditions.item.storage.SuperStorageCell;
 import dan200.computercraft.shared.util.NBTUtil;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
@@ -335,6 +336,8 @@ public class AppEngApi {
                     }
                 } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof SuperStorageCell superStorageCell)) {
                     total += superStorageCell.getKiloBytes() * 1024;
+                } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
+                    total += storageCell.getKiloBytes() * 1024;
                 }
             }
         }
@@ -382,6 +385,8 @@ public class AppEngApi {
                     }
                 } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof SuperStorageCell superStorageCell) {
                     total += superStorageCell.getKiloBytes() * 1024;
+                } else if (APAddons.aeAdditionsLoaded && (stack.getItem() instanceof StorageCell storageCell)) {
+                    total += storageCell.getKiloBytes() * 1024;
                 }
             }
         }
@@ -447,6 +452,12 @@ public class AppEngApi {
                     long numItemsInCell = stack.getTag().getLong("ic");
 
                     used += numItemsInCell;
+                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell) {
+                    if (stack.getTag() == null)
+                        continue;
+                    long numItemsInCell = stack.getTag().getLong("ic");
+
+                    used += numItemsInCell;
                 }
             }
         }
@@ -492,7 +503,13 @@ public class AppEngApi {
 
                         used += ((int) Math.ceil(((double) numBucketsInCell) / 8)) + ((long) bytesPerType * numOfType);
                     }
-                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof SuperStorageCell superStorageCell) {
+                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof SuperStorageCell) {
+                    if (stack.getTag() == null)
+                        continue;
+                    long numItemsInCell = stack.getTag().getLong("ic");
+
+                    used += numItemsInCell;
+                } else if (APAddons.aeAdditionsLoaded && stack.getItem() instanceof StorageCell) {
                     if (stack.getTag() == null)
                         continue;
                     long numItemsInCell = stack.getTag().getLong("ic");


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] (not needed) Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
When adding some methods for AE2 network usage, https://github.com/IntelligenceModding/AdvancedPeripherals/pull/404 seems to not have taken into account portable cells. Right now, these cells can be put in a AE2 Drive, but won't be counted by methods like `getTotalItemStorage()`

Looking around the source, it seems like `IBasicCellItem` is a common interface for classical and portable cells, so I used it instead.

* **What is the current behavior?** (You can also link to an open issue here)
See above


* **What is the new behavior (if this is a feature change)?**
See above

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No

* **Other information**:

