### PR TITLE
Fix NullPointerException when server ticking

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/util/ServerWorker.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/ServerWorker.java
@@ -5,13 +5,13 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Mod.EventBusSubscriber(modid = AdvancedPeripherals.MOD_ID)
 public class ServerWorker {
 
-    private static final Queue<Runnable> callQueue = new ArrayDeque<>();
+    private static final Queue<Runnable> callQueue = new ConcurrentLinkedQueue<>();
 
     public static void add(final Runnable call) {
         if (call != null) {

--- a/src/main/java/de/srendi/advancedperipherals/common/util/ServerWorker.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/ServerWorker.java
@@ -14,14 +14,19 @@ public class ServerWorker {
     private static final Queue<Runnable> callQueue = new ArrayDeque<>();
 
     public static void add(final Runnable call) {
-        callQueue.add(call);
+        if (call != null) {
+            callQueue.add(call);
+        }
     }
 
     @SubscribeEvent
     public static void serverTick(TickEvent.ServerTickEvent event) {
         if (event.phase == TickEvent.Phase.END) {
-            while (!callQueue.isEmpty()) {
+            while (true) {
                 final Runnable runnable = callQueue.poll();
+                if (runnable == null) {
+                    return;
+                }
                 AdvancedPeripherals.debug("Running queued server worker call: " + runnable);
                 runnable.run();
             }


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)

Some mod may call `ServerWorker.tick` with null value, this PR ensure null value never go to the queue, and if it did somehow, the null will never be executed

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No

* **Other information**:

