### PR TITLE
Add slot field to inventoryManager.getItemInHand

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
@@ -23,8 +23,8 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.PlayerArmorInvWrapper;
 import net.minecraftforge.items.wrapper.PlayerInvWrapper;
 import net.minecraftforge.items.wrapper.PlayerOffhandInvWrapper;
-import org.jetbrains.annotations.NotNull;
 
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -188,8 +188,13 @@ public class InventoryManagerPeripheral extends BasePeripheral<BlockEntityPeriph
     }
 
     @LuaFunction(mainThread = true)
+    public final int getHandSlot() throws LuaException {
+        return getOwnerPlayer().getInventory().selected;
+    }
+
+    @LuaFunction(mainThread = true)
     public final Map<String, Object> getItemInHand() throws LuaException {
-        return LuaConverter.stackToObjectWithSlot(getOwnerPlayer().getMainHandItem(), getOwnerPlayer().getInventory().selected);
+        return LuaConverter.itemStackToObject(getOwnerPlayer().getMainHandItem(), getOwnerPlayer().getInventory().selected);
     }
 
     @LuaFunction(mainThread = true)

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/InventoryManagerPeripheral.java
@@ -189,7 +189,7 @@ public class InventoryManagerPeripheral extends BasePeripheral<BlockEntityPeriph
 
     @LuaFunction(mainThread = true)
     public final Map<String, Object> getItemInHand() throws LuaException {
-        return LuaConverter.itemStackToObject(getOwnerPlayer().getMainHandItem());
+        return LuaConverter.stackToObjectWithSlot(getOwnerPlayer().getMainHandItem(), getOwnerPlayer().getInventory().selected);
     }
 
     @LuaFunction(mainThread = true)

--- a/src/main/java/de/srendi/advancedperipherals/common/util/LuaConverter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/LuaConverter.java
@@ -19,8 +19,9 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.IForgeShearable;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
-import org.jetbrains.annotations.NotNull;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -104,8 +105,11 @@ public class LuaConverter {
         return map;
     }
 
+    @Nullable
     public static Map<String, Object> itemStackToObject(@NotNull ItemStack stack) {
-        if (stack.isEmpty()) return new HashMap<>();
+        if (stack.isEmpty()) {
+            return null;
+        }
         Map<String, Object> map = itemToObject(stack.getItem());
         CompoundTag nbt = stack.copy().getOrCreateTag();
         map.put("count", stack.getCount());
@@ -141,8 +145,11 @@ public class LuaConverter {
      * @return a Map containing proper item stack details
      * @see InventoryManagerPeripheral#getItems()
      */
+    @Nullable
     public static Map<String, Object> stackToObjectWithSlot(@NotNull ItemStack stack, int slot) {
-        if (stack.isEmpty()) return new HashMap<>();
+        if (stack.isEmpty()) {
+            return null;
+        }
         Map<String, Object> map = itemStackToObject(stack);
         map.put("slot", slot);
         return map;

--- a/src/main/java/de/srendi/advancedperipherals/common/util/LuaConverter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/LuaConverter.java
@@ -151,7 +151,7 @@ public class LuaConverter {
             return null;
         }
         Map<String, Object> map = itemStackToObject(stack);
-        map.put("slot", slot);
+        map.put("slot", slot + 1);
         return map;
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ItemFilter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ItemFilter.java
@@ -69,14 +69,14 @@ public class ItemFilter extends GenericFilter {
         }
         if (item.containsKey("fromSlot")) {
             try {
-                itemFilter.fromSlot = TableHelper.getIntField(item, "fromSlot");
+                itemFilter.fromSlot = TableHelper.getIntField(item, "fromSlot") - 1;
             } catch (LuaException luaException) {
                 return Pair.of(null, "NO_VALID_FROMSLOT");
             }
         }
         if (item.containsKey("toSlot")) {
             try {
-                itemFilter.toSlot = TableHelper.getIntField(item, "toSlot");
+                itemFilter.toSlot = TableHelper.getIntField(item, "toSlot") - 1;
             } catch (LuaException luaException) {
                 return Pair.of(null, "NO_VALID_TOSLOT");
             }


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Feature

* **What is the current behavior?** (You can also link to an open issue here)
  The getItemInHand method will not return the slot info

* **What is the new behavior (if this is a feature change)?**
  Now it will

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  Yes, the player have to check `nil` now instead of `{}` for empty item
  And the slots are begin with 1 now

* **Other information**:
  - https://github.com/IntelligenceModding/Advanced-Peripherals-Features/issues/67
  - #587

close IntelligenceModding/Advanced-Peripherals-Features#67
