### PR TITLE
fix player can bypass the maximum chatbox/playerdetector range by setting a negative range

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -111,10 +111,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(4, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
+            int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             MutableComponent component = Component.Serializer.fromJson(message);
             if (component == null)
@@ -131,7 +128,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                     continue;
-                if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
+                if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
                     player.sendSystemMessage(preparedMessage);
             }
             return MethodResult.of(true);
@@ -143,10 +140,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(4, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
+            int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             if (checkBrackets(arguments.optString(2)))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
@@ -159,7 +153,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                     continue;
-                if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
+                if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
                     player.sendSystemMessage(preparedMessage);
             }
             return MethodResult.of(true);
@@ -173,9 +167,6 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = Math.min(arguments.optInt(5, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -196,7 +187,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
 
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
                 player.sendSystemMessage(preparedMessage);
             return MethodResult.of(true);
         });
@@ -210,10 +201,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String title = arguments.getString(1);
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(6, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
+            int range = arguments.optInt(6, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -239,7 +227,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
 
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange)) {
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange)) {
                 ToastToClientPacket packet = new ToastToClientPacket(titleComponent, preparedMessage);
                 APNetworking.sendTo(packet, player);
             }
@@ -254,10 +242,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String message = arguments.getString(0);
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(5, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
+            int range = arguments.optInt(5, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -274,7 +259,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
 
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
                 player.sendSystemMessage(preparedMessage, false);
             return MethodResult.of(true);
         });
@@ -287,10 +272,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String title = arguments.getString(1);
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(6, -1), maxRange);
-            if (range < 0) {
-                range = maxRange;
-            }
+            int range = arguments.optInt(6, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -308,7 +290,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
 
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange)) {
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange)) {
                 ToastToClientPacket packet = new ToastToClientPacket(Component.literal(title), preparedMessage);
                 APNetworking.sendTo(packet, player);
             }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -111,8 +111,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(4, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(4, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             MutableComponent component = Component.Serializer.fromJson(message);
             if (component == null)
@@ -141,8 +143,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(4, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(4, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             if (checkBrackets(arguments.optString(2)))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
@@ -168,8 +172,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String message = arguments.getString(0);
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(5, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(5, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -204,8 +210,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String title = arguments.getString(1);
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(6, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(6, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -246,8 +254,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String message = arguments.getString(0);
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(5, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(5, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)
@@ -277,8 +287,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String title = arguments.getString(1);
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(6, maxRange);
-            range = maxRange == -1 ? range : Math.min(range, APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get());
+            int range = Math.min(arguments.optInt(6, -1), maxRange);
+            if (range < 0) {
+                range = maxRange;
+            }
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/PlayerDetectorPeripheral.java
@@ -97,7 +97,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
         for (ServerPlayer player : getPlayers()) {
             if (!isAllowedMultiDimensional() && player.getLevel().dimension() != dimension)
                 continue;
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE))
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE))
                 playersName.add(player.getName().getString());
         }
         return playersName;
@@ -142,7 +142,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
         for (ServerPlayer player : getPlayers()) {
             if (!isAllowedMultiDimensional() && player.getLevel().dimension() != dimension)
                 continue;
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE)) return true;
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE)) return true;
         }
         return false;
     }
@@ -185,7 +185,7 @@ public class PlayerDetectorPeripheral extends BasePeripheral<IPeripheralOwner> {
         for (Player player : getPlayers()) {
             if (!isAllowedMultiDimensional() && player.getLevel().dimension() != dimension)
                 continue;
-            if (range == -1 || CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE)) {
+            if (CoordUtil.isInRange(getPos(), getLevel(), player, range, MAX_RANGE)) {
                 if(player.getName().getString().equals(username))
                     return true;
             }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/CoordUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/CoordUtil.java
@@ -19,8 +19,9 @@ public class CoordUtil {
     public static boolean isInRange(@Nullable BlockPos pos, @Nullable Level world, @Nullable Player player, int range, int maxRange) {
         // There are rare cases where these are null. For example if a player detector pocket computer runs while not in a player inventory
         // Fixes https://github.com/SirEndii/AdvancedPeripherals/issues/356
-        if (pos == null || world == null || player == null)
+        if (pos == null || world == null || player == null) {
             return false;
+        }
 
         range = maxRange == -1 ? range : Math.min(Math.abs(range), maxRange);
         return isPlayerInBlockRange(pos, world, player, (double) range);

--- a/src/main/java/de/srendi/advancedperipherals/common/util/CoordUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/CoordUtil.java
@@ -16,6 +16,17 @@ import java.util.Locale;
 
 public class CoordUtil {
 
+    /**
+     * isInRange checks if the player is in the range
+     *
+     * @param pos the position to start check
+     * @param world the world to start check
+     * @param player the player going to be check
+     * @param range the range that user want to reach, must be -1, 0, or a positive number
+     * @param maxRange the maximum range the user can reach, must be -1, 0, or a positive number
+     *
+     * @return If the player is in the {@code range} as well as in the {@code maxRange}, or {@code range} and {@code maxRange} are -1
+     */
     public static boolean isInRange(@Nullable BlockPos pos, @Nullable Level world, @Nullable Player player, int range, int maxRange) {
         // There are rare cases where these are null. For example if a player detector pocket computer runs while not in a player inventory
         // Fixes https://github.com/SirEndii/AdvancedPeripherals/issues/356
@@ -23,7 +34,17 @@ public class CoordUtil {
             return false;
         }
 
-        range = maxRange == -1 ? range : Math.min(Math.abs(range), maxRange);
+        if (range == 0 || maxRange == 0) {
+            return false;
+        }
+        if (range < 0) {
+            if (maxRange < 0) {
+                return true;
+            }
+            range = maxRange;
+        } else if (maxRange > 0 && range > maxRange) {
+            range = maxRange;
+        }
         return isPlayerInBlockRange(pos, world, player, (double) range);
     }
 


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
  - #623

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  No
