### PR TITLE
Continue to fix chatbox range, forgot to remove a Math.min

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -166,7 +166,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String message = arguments.getString(0);
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = Math.min(arguments.optInt(5, -1), maxRange);
+            int range = arguments.optInt(5, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             ServerPlayer player = getPlayer(playerName);
             if (player == null)


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
   Math.min will make it always returns `-1`

* **What is the new behavior (if this is a feature change)?**
   N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
   Nop

* **Other information**:
  I'm dumb https://github.com/IntelligenceModding/AdvancedPeripherals/pull/624/files#diff-169e726cb0aaf509df0e51437a363b33fb140f8627cc69c7bdb06ab6c04c2ac4R169
