### PR TITLE
clear owner after put memory card into inventory manager

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/InventoryManagerEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/InventoryManagerEntity.java
@@ -91,12 +91,7 @@ public class InventoryManagerEntity extends PeripheralBlockEntity<InventoryManag
         if (this.owner == null) {
             return null;
         }
-        // Loop through all players and check if the player is online
-        for (Player player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
-            if (player.getUUID().equals(this.owner)) {
-                return player;
-            }
-        }
-        return null;
+        Player player = ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayer(this.owner);
+        return player;
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/InventoryManagerEntity.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/blocks/blockentities/InventoryManagerEntity.java
@@ -8,6 +8,7 @@ import de.srendi.advancedperipherals.common.items.MemoryCardItem;
 import de.srendi.advancedperipherals.common.setup.BlockEntityTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -15,10 +16,14 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.server.ServerLifecycleHooks;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.util.UUID;
 
 public class InventoryManagerEntity extends PeripheralBlockEntity<InventoryManagerPeripheral> implements IInventoryBlock<InventoryManagerContainer> {
+
+    private UUID owner = null;
 
     public InventoryManagerEntity(BlockPos pos, BlockState state) {
         super(BlockEntityTypes.INVENTORY_MANAGER.get(), pos, state);
@@ -45,21 +50,52 @@ public class InventoryManagerEntity extends PeripheralBlockEntity<InventoryManag
         return itemStackIn.getItem() instanceof MemoryCardItem;
     }
 
+    @Override
+    public void setItem(int index, @NotNull ItemStack stack) {
+        if (stack.getItem() instanceof MemoryCardItem && stack.hasTag() && stack.getTag().contains("ownerId")) {
+            UUID owner = stack.getTag().getUUID("ownerId");
+            this.owner = owner;
+            stack.getTag().remove("ownerId");
+            stack.getTag().remove("owner");
+        } else {
+            this.owner = null;
+        }
+        super.setItem(index, stack);
+    }
+
     @NotNull
     @Override
     public Component getDisplayName() {
         return Component.translatable("block.advancedperipherals.inventory_manager");
     }
 
+    @Override
+    public void load(CompoundTag data) {
+        if (data.contains("ownerId")) {
+            this.owner = data.getUUID("ownerId");
+        }
+        super.load(data);
+        // Fresh the memory card for backward compatibility
+        this.setItem(0, this.getItem(0));
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag data) {
+        super.saveAdditional(data);
+        if (this.owner != null) {
+            data.putUUID("ownerId", this.owner);
+        }
+    }
+
     public Player getOwnerPlayer() {
-        //Checks if the tile entity has an item in his inventory
-        if (items.get(0).isEmpty()) return null;
-        ItemStack stack = items.get(0);
-        //Checks if the item contains the owner name
-        if (!stack.getOrCreateTag().contains("owner")) return null;
-        //Loop through all players and check if the player is online
-        for (Player entity : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
-            if (entity.getName().getString().equals(stack.getOrCreateTag().getString("owner"))) return entity;
+        if (this.owner == null) {
+            return null;
+        }
+        // Loop through all players and check if the player is online
+        for (Player player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
+            if (player.getUUID().equals(this.owner)) {
+                return player;
+            }
         }
         return null;
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/items/MemoryCardItem.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/items/MemoryCardItem.java
@@ -3,6 +3,7 @@ package de.srendi.advancedperipherals.common.items;
 import de.srendi.advancedperipherals.common.configuration.APConfig;
 import de.srendi.advancedperipherals.common.items.base.BaseItem;
 import de.srendi.advancedperipherals.common.util.EnumColor;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -28,21 +29,27 @@ public class MemoryCardItem extends BaseItem {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level levelIn, List<Component> tooltip, TooltipFlag flagIn) {
         super.appendHoverText(stack, levelIn, tooltip, flagIn);
-        if (stack.getOrCreateTag().contains("owner"))
-            tooltip.add(EnumColor.buildTextComponent(Component.translatable("item.advancedperipherals.tooltip.memory_card.bound", stack.getOrCreateTag().getString("owner"))));
-
+        CompoundTag data = stack.getOrCreateTag();
+        // TODO: remove the owner name field
+        if (data.contains("ownerId") && data.contains("owner")) {
+            tooltip.add(EnumColor.buildTextComponent(Component.translatable("item.advancedperipherals.tooltip.memory_card.bound", data.getString("owner"))));
+        }
     }
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level worldIn, Player playerIn, InteractionHand handIn) {
         if (!worldIn.isClientSide) {
             ItemStack stack = playerIn.getItemInHand(handIn);
-            if (stack.getOrCreateTag().contains("owner")) {
+            CompoundTag data = stack.getOrCreateTag();
+            // TODO: remove the owner name field
+            if (data.contains("ownerId") || data.contains("owner")) {
                 playerIn.displayClientMessage(Component.translatable("text.advancedperipherals.removed_player"), true);
-                stack.getOrCreateTag().remove("owner");
+                data.remove("ownerId");
+                data.remove("owner");
             } else {
                 playerIn.displayClientMessage(Component.translatable("text.advancedperipherals.added_player"), true);
-                stack.getOrCreateTag().putString("owner", playerIn.getName().getString());
+                data.putUUID("ownerId", playerIn.getUUID());
+                data.putString("owner", playerIn.getName().getString());
             }
         }
         return super.use(worldIn, playerIn, handIn);

--- a/src/main/java/de/srendi/advancedperipherals/common/items/MemoryCardItem.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/items/MemoryCardItem.java
@@ -30,7 +30,7 @@ public class MemoryCardItem extends BaseItem {
     public void appendHoverText(ItemStack stack, @Nullable Level levelIn, List<Component> tooltip, TooltipFlag flagIn) {
         super.appendHoverText(stack, levelIn, tooltip, flagIn);
         CompoundTag data = stack.getOrCreateTag();
-        // TODO: remove the owner name field
+        // TODO <0.8>: remove the owner name field
         if (data.contains("ownerId") && data.contains("owner")) {
             tooltip.add(EnumColor.buildTextComponent(Component.translatable("item.advancedperipherals.tooltip.memory_card.bound", data.getString("owner"))));
         }
@@ -41,7 +41,7 @@ public class MemoryCardItem extends BaseItem {
         if (!worldIn.isClientSide) {
             ItemStack stack = playerIn.getItemInHand(handIn);
             CompoundTag data = stack.getOrCreateTag();
-            // TODO: remove the owner name field
+            // TODO <0.8>: remove the owner name field
             if (data.contains("ownerId") || data.contains("owner")) {
                 playerIn.displayClientMessage(Component.translatable("text.advancedperipherals.removed_player"), true);
                 data.remove("ownerId");


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Feature

* **What is the current behavior?** (You can also link to an open issue here)
  - IntelligenceModding/Advanced-Peripherals-Features#87

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  - Kind of, player cannot automaticly put memory card in and out from inventory manager anymore, or the owner will be cleared.

