### PR TITLE
Add wandering trader config

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
@@ -21,7 +21,7 @@ public class WorldConfig implements IAPConfig {
         enableVillagerStructures = builder.comment("Enable the villager structures for the computer scientist.").define("enableVillagerStructures", true);
         givePlayerBookOnJoin = builder.comment("Gives the ap documentation to new players.").define("givePlayerBookOnJoin", true);
         villagerStructureWeight = builder.comment("The weight of the villager structures.").defineInRange("villagerStructureWeight", 10, 0, 16000);
-        enableWanderingTraderTrades = builder.comment("Enable new wandering trader trades.").define("enableWanderingVillagerTrades", true);
+        enableWanderingTraderTrades = builder.comment("Enable new wandering trader trades.").define("enableWanderingTraderTrades", true);
 
         builder.pop();
         configSpec = builder.build();

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
@@ -10,6 +10,7 @@ public class WorldConfig implements IAPConfig {
     public final ForgeConfigSpec.BooleanValue enableVillagerStructures;
     public final ForgeConfigSpec.BooleanValue givePlayerBookOnJoin;
     public final ForgeConfigSpec.IntValue villagerStructureWeight;
+    public final ForgeConfigSpec.BooleanValue enableWanderingTraderTrades;
     private final ForgeConfigSpec configSpec;
 
     public WorldConfig() {
@@ -20,6 +21,7 @@ public class WorldConfig implements IAPConfig {
         enableVillagerStructures = builder.comment("Enable the villager structures for the computer scientist.").define("enableVillagerStructures", true);
         givePlayerBookOnJoin = builder.comment("Gives the ap documentation to new players.").define("givePlayerBookOnJoin", true);
         villagerStructureWeight = builder.comment("The weight of the villager structures.").defineInRange("villagerStructureWeight", 10, 0, 16000);
+        enableWanderingTraderTrades = builder.comment("Enable new wandering trader trades.").define("enableWanderingVillagerTrades", true);
 
         builder.pop();
         configSpec = builder.build();

--- a/src/main/java/de/srendi/advancedperipherals/common/village/VillagerTrades.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/village/VillagerTrades.java
@@ -2,6 +2,7 @@ package de.srendi.advancedperipherals.common.village;
 
 import dan200.computercraft.shared.Registry;
 import de.srendi.advancedperipherals.AdvancedPeripherals;
+import de.srendi.advancedperipherals.common.configuration.APConfig;
 import de.srendi.advancedperipherals.common.setup.Blocks;
 import de.srendi.advancedperipherals.common.setup.CCRegistration;
 import de.srendi.advancedperipherals.common.setup.Items;
@@ -19,12 +20,14 @@ public class VillagerTrades {
 
     @SubscribeEvent
     public static void registerWanderingTrade(WandererTradesEvent event) {
-        TradeBuilder.createTrade(event, Blocks.PERIPHERAL_CASING.get(), VillagerTrade.Type.ITEM_FOR_EMERALD, 1, 1)
-                .setMaxUses(8)
-                .build();
-        TradeBuilder.createTrade(event, Registry.ModBlocks.TURTLE_ADVANCED.get(), VillagerTrade.Type.ITEM_FOR_EMERALD, 2, 1)
-                .setMaxUses(8)
-                .build();
+        if (APConfig.WORLD_CONFIG.enableWanderingTraderTrades.get()) {
+            TradeBuilder.createTrade(event, Blocks.PERIPHERAL_CASING.get(), VillagerTrade.Type.ITEM_FOR_EMERALD, 1, 1)
+                    .setMaxUses(8)
+                    .build();
+            TradeBuilder.createTrade(event, Registry.ModBlocks.TURTLE_ADVANCED.get(), VillagerTrade.Type.ITEM_FOR_EMERALD, 2, 1)
+                    .setMaxUses(8)
+                    .build();
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [ ] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). This is not mandatory
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?**
It adds a config option for the wandering trader trades that AdvancedPeripherals adds. This allows people to disable the trades if they would like.

* **What is the current behavior?** (You can also link to an open issue here)
Wandering trader trades can't be disabled.

* **What is the new behavior (if this is a feature change)?**
Wandering trader trades can be disabled.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No

* **Other information**:

