### PR TITLE
Fix Peripheral throws NullPointerException when invoking getName method

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
@@ -33,13 +33,14 @@ public class BlockEntityPeripheralOwner<T extends BlockEntity & IPeripheralTileE
     @Nullable
     @Override
     public String getCustomName() {
-        String result = "";
-        
         if (tileEntity instanceof Nameable nameableEntity) {
-            result = nameableEntity.getCustomName().getString();
+            Component name = nameableEntity.getCustomName();
+            if (name != null) {
+                return name.getString();
+            }
         }
         
-        return result;
+        return "";
     }
 
     @NotNull

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
@@ -9,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.FrontAndTop;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.Nameable;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
@@ -40,7 +40,6 @@ public class BlockEntityPeripheralOwner<T extends BlockEntity & IPeripheralTileE
                 return name.getString();
             }
         }
-        
         return "";
     }
 


### PR DESCRIPTION
- fix null pointer exception when invoking getName fix #640
- add missing import

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
  - #640

* **What is the new behavior (if this is a feature change)?**
  Now getName returns an empty string instead of throws error

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  No

* **Other information**:
  1.19.2 do not have this bug

