### PR TITLE
rename getEnergy -> getStoredEnergy

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/BlockEntityPeripheralOwner.java
@@ -40,8 +40,7 @@ public class BlockEntityPeripheralOwner<T extends BlockEntity & IPeripheralTileE
                 return name.getString();
             }
         }
-
-        return result;
+        return "";
     }
 
     @NotNull

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnderCellIntegration.java
@@ -11,8 +11,15 @@ public class EnderCellIntegration implements APGenericPeripheral {
         return "enderCell";
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(EnderCellTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(EnderCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
@@ -16,8 +16,14 @@ public class EnergyCellIntegration implements APGenericPeripheral {
         return "Energy Cell";
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(EnergyCellTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(EnergyCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/EnergyCellIntegration.java
@@ -22,6 +22,7 @@ public class EnergyCellIntegration implements APGenericPeripheral {
     public final double getEnergy(EnergyCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
+
     @LuaFunction(mainThread = true)
     public final double getStoredEnergy(EnergyCellTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/FurnatorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/FurnatorIntegration.java
@@ -17,8 +17,15 @@ public class FurnatorIntegration implements APGenericPeripheral {
         return blockEntity.isBurning();
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(FurnatorTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(FurnatorTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/MagmatorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/MagmatorIntegration.java
@@ -13,8 +13,15 @@ public class MagmatorIntegration implements APGenericPeripheral {
         return "magmator";
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(MagmatorTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(MagmatorTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ReactorIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ReactorIntegration.java
@@ -40,8 +40,17 @@ public class ReactorIntegration implements APGenericPeripheral {
         return blockEntity.core().get().redstone.perCent();
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(ReactorPartTile blockEntity) {
+        if (blockEntity.core().isEmpty())
+            return 0.0d;
+        return blockEntity.core().get().getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(ReactorPartTile blockEntity) {
         if (blockEntity.core().isEmpty())
             return 0.0d;
         return blockEntity.core().get().getEnergy().getEnergyStored();

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/SolarPanelIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/SolarPanelIntegration.java
@@ -16,8 +16,15 @@ public class SolarPanelIntegration implements APGenericPeripheral {
         return "Solar Panel";
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(SolarTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(SolarTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ThermoIntegration.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/powah/ThermoIntegration.java
@@ -16,8 +16,15 @@ public class ThermoIntegration implements APGenericPeripheral {
         return "Thermo generator";
     }
 
+    // TODO: remove in the next major version
+    @Deprecated(forRemoval = true, since = "1.20.1-0.7.41r")
     @LuaFunction(mainThread = true)
     public final double getEnergy(ThermoTile blockEntity) {
+        return blockEntity.getEnergy().getEnergyStored();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final double getStoredEnergy(ThermoTile blockEntity) {
         return blockEntity.getEnergy().getEnergyStored();
     }
 


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
  Powah's stuff's getEnergy will return an integer since there is a same name method in cc:t

* **What is the new behavior (if this is a feature change)?**
  After rename it will not conflict anymore, and should return a double now

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  No

* **Other information**:
   1.19.2 do not have this bug, but I do not know if I still need to add a method called `getStoredEnergy` in 1.19.2