### PR TITLE
Fix entity operation does not have enough reach range than expected

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataEntityHandPlugin.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataEntityHandPlugin.java
@@ -56,7 +56,7 @@ public class AutomataEntityHandPlugin extends AutomataCorePlugin {
             if (automataCore.hasAttribute(AutomataCorePeripheral.ATTR_STORING_TOOL_DURABILITY))
                 selectedTool.setDamageValue(previousDamageValue);
 
-            return MethodResult.of(true, result.toString());
+            return MethodResult.of(result.consumesAction(), result.toString());
         });
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataSoulFeedingPlugin.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataSoulFeedingPlugin.java
@@ -24,7 +24,7 @@ public class AutomataSoulFeedingPlugin extends AutomataCorePlugin {
 
         InteractionResult result = owner.withPlayer(APFakePlayer::useOnEntity);
         automataCore.addRotationCycle(3);
-        return MethodResult.of(true, result.toString());
+        return MethodResult.of(result.consumesAction(), result.toString());
     }
 
     @Override

--- a/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
@@ -44,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
@@ -318,7 +318,7 @@ public class APFakePlayer extends FakePlayer {
         if (skipEntity)
             return blockHit;
 
-        List<Entity> entities = level.getEntities(this, getBoundingBox().expandTowards(look.x * range, look.y * range, look.z * range).inflate(1, 1, 1), collidablePredicate);
+        List<Entity> entities = level.getEntities(this, getBoundingBox().expandTowards(look.x * range, look.y * range, look.z * range).inflate(1), collidablePredicate);
 
         LivingEntity closestEntity = null;
         Vec3 closestVec = null;
@@ -328,29 +328,20 @@ public class APFakePlayer extends FakePlayer {
                 continue;
             // Add litter bigger that just pick radius
             AABB box = entityHit.getBoundingBox().inflate(entityHit.getPickRadius() + 0.5);
-            Optional<Vec3> clipResult = box.clip(origin, target);
-
             if (box.contains(origin)) {
-                if (closestDistance >= 0.0D) {
-                    closestEntity = (LivingEntity) entityHit;
-                    closestVec = clipResult.orElse(origin);
-                    closestDistance = 0.0D;
-                }
-            } else if (clipResult.isPresent()) {
+                closestEntity = (LivingEntity) entityHit;
+                closestVec = clipResult.orElse(origin);
+                closestDistance = 0;
+                break;
+            }
+            Optional<Vec3> clipResult = box.clip(origin, target);
+            if (clipResult.isPresent()) {
                 Vec3 clipVec = clipResult.get();
                 double distance = origin.distanceTo(clipVec);
-
-                if (distance < closestDistance || closestDistance == 0.0D) {
-                    if (entityHit == entityHit.getRootVehicle() && !entityHit.canRiderInteract()) {
-                        if (closestDistance == 0.0D) {
-                            closestEntity = (LivingEntity) entityHit;
-                            closestVec = clipVec;
-                        }
-                    } else {
-                        closestEntity = (LivingEntity) entityHit;
-                        closestVec = clipVec;
-                        closestDistance = distance;
-                    }
+                if (distance < closestDistance) {
+                    closestEntity = (LivingEntity) entityHit;
+                    closestVec = clipVec;
+                    closestDistance = distance;
                 }
             }
         }


### PR DESCRIPTION
- make some change to fake player
- fix entity operation does not have enough reach range than expected

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
   Feature

* **What is the current behavior?** (You can also link to an open issue here)
   The entity have to stick on the turtle in order to interact with Automata cores.

* **What is the new behavior (if this is a feature change)?**
   Now the Automata core can operate entities with normal player reach range.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
   N/A

* **Other information**:
   Should we also add pitch/yaw stuff for entity operations?
