### PR TITLE
Add `broadcast` option to the chat box

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -211,8 +211,6 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
     public final MethodResult sendFormattedMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
-            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             MutableComponent component = Component.Serializer.fromJson(message);
             if (component == null) {
@@ -236,6 +234,19 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "illegal prefix");
             }
             preparedMessage.append(component);
+
+            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
+            int range = arguments.optInt(4, -1);
+            if (
+                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                    && maxRange == -1
+                    && range == -1
+            ) {
+                ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
+                return MethodResult.of(true);
+            }
+
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension) {
                     continue;
@@ -252,8 +263,6 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
     public final MethodResult sendMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
             String message = arguments.getString(0);
-            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
             if (checkBrackets(arguments.optString(2))) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
@@ -268,6 +277,19 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "illegal prefix");
             }
             preparedMessage.append(message);
+
+            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
+            int range = arguments.optInt(4, -1);
+            if (
+                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                    && maxRange == -1
+                    && range == -1
+            ) {
+                ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
+                return MethodResult.of(true);
+            }
+
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.getLevel().dimension() != dimension) {
                     continue;

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
@@ -44,6 +44,7 @@ public class PeripheralsConfig implements IAPConfig {
     public final ForgeConfigSpec.ConfigValue<String> defaultChatBoxPrefix;
     public final ForgeConfigSpec.IntValue chatBoxMaxRange;
     public final ForgeConfigSpec.BooleanValue chatBoxMultiDimensional;
+    public final ForgeConfigSpec.BooleanValue chatBoxBroadcast;
     public final ForgeConfigSpec.BooleanValue chatBoxPreventRunCommand;
     public final ForgeConfigSpec.BooleanValue chatBoxWrapCommand;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> chatBoxBannedCommands;
@@ -147,6 +148,7 @@ public class PeripheralsConfig implements IAPConfig {
         defaultChatBoxPrefix = builder.comment("Defines default chatbox prefix").define("defaultChatBoxPrefix", "AP");
         chatBoxMaxRange = builder.comment("Defines the maximal range of the chat box in blocks. -1 for infinite. If the range is not -1, players in other dimensions won't able to receive messages").defineInRange("chatBoxMaxRange", -1, -1, 30000000);
         chatBoxMultiDimensional = builder.comment("If true, the chat box is able to send messages to other dimensions than its own").define("chatBoxMultiDimensional", true);
+        chatBoxBroadcast = builder.comment("If true, chat box will 'broadcast' the messages instead of sending one individually to each player. This option does not affect anything directly, and relies on other mods to utilise this behavior (for example, mods that bridge minecraft chat to other platforms can intercept broadcasted messages and relay them, unlike individually sent ones). This option will only go in effect if `chatBoxMaxRange` is set to `-1` and `chatBoxMultiDimensional` is also set to `true`.").define("chatBoxBroadcast", true);
         chatBoxPreventRunCommand = builder.comment("If true, the chat box cannot use 'run_command' action").define("chatBoxPreventRunCommand", false);
         chatBoxWrapCommand = builder.comment("If true, the chat box will wrap and execute 'run_command' or 'suggest_command' action with zero permission, in order to prevent operators accidently run dangerous commands.").define("chatBoxWrapCommand", true);
         chatBoxBannedCommands = builder.comment("These commands below will not be able to send by 'run_command' or 'suggest_command' action. It will match as prefix if starts with '/', other wise use regex pattern").defineList("chatBoxBannedCommands", chatBoxDefaultBannedCommands, (o) -> o instanceof String value && value.length() > 0);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message are well described (they are ok, I can amend the description if strictly necessary)
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
If possible (range, max range are infinite and chat box is multidimensional), we use `broadcastSystemMessage`, instead of sending one to each player.

* **What is the current behavior?** (You can also link to an open issue here)
We send a message to each player individually, no matter the config options.

* **What is the new behavior (if this is a feature change)?**
Described above.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
None, internal change.

* **Other information**:
Main motivation for this change is: make the intent more clear, so mods that operate on chat (specifically tested with [mc2discord](https://github.com/DenisD3D/Mc2Discord), mixins only into `broadcastSystemMessage`), can identify the messages and process them.
