### PR TITLE
Allow operation cooldown to be 0

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/operations/SimpleFreeOperation.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/operations/SimpleFreeOperation.java
@@ -18,7 +18,7 @@ public enum SimpleFreeOperation implements IPeripheralOperation<Object> {
 
     @Override
     public void addToConfig(ForgeConfigSpec.Builder builder) {
-        cooldown = builder.defineInRange(settingsName() + "Cooldown", defaultCooldown, 1_000, Integer.MAX_VALUE);
+        cooldown = builder.defineInRange(settingsName() + "Cooldown", defaultCooldown, 0, Integer.MAX_VALUE);
     }
 
     @Override


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message are well described (they are ok, can be amended if strictly necessary)
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Allows for the cooldown to be set to 0, **the default cooldown is still the same**, so this doesn't change anything for most players, and allows for the folks who know what they're doing to lift the cooldown altogether.

* **What is the current behavior?** (You can also link to an open issue here)
Cooldown is set to at least 1000, and currently cannot be lower (unless you are going to patch the mod which I did in my survival world but wanted to upstream the changes)

* **What is the new behavior (if this is a feature change)?**
Described above.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
None, config change.

* **Other information**:
It's fine if this change cannot be upstreamed due to security concerns or whatever, I can still patch and build the mod myself for my worlds, but the cooldown can really get annoying if you're using the vanilla mod, and especially busy looping to wait for a message to leave the computer and sent in the chat makes the players want to code some sort of a "message sender domain" which is crazy as hell for this small thing, but is necessary for the correct and timely operation of computers, or if one trusts every computer on the server (you're playing only with a friend, not a public server), you could just lift the cooldown altogether and stop worrying about it.