### PR TITLE
Update build-and-test.yaml

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   workflow_dispatch:
   push:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -11,5 +11,3 @@ on:
 jobs:
   build-and-test:
     uses: IntelligenceModding/actions/.github/workflows/build-and-test.yaml@master
-    with:
-      ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
We should just use pull_request not pull_request_target

pull_request_target will executes code on the base commit, but not the PR commits.
pull_request_target is used for prevent secure hack, but I think we don't need worry about the hack?