### PR TITLE
Several Automata Turtle fixes

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/FuelAbility.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/FuelAbility.java
@@ -9,6 +9,7 @@ import net.minecraft.core.component.PatchedDataComponentMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static de.srendi.advancedperipherals.common.setup.DataComponents.FUEL_CONSUMPTION_RATE;
 
@@ -30,7 +31,8 @@ public abstract class FuelAbility<T extends IPeripheralOwner> implements IOwnerA
      */
     protected int getConsumptionRate() {
         DataComponentPatch settings = owner.getDataStorage();
-        int rate = settings.get(FUEL_CONSUMPTION_RATE.get()).get();
+        Optional<? extends Integer> opt = settings.get(FUEL_CONSUMPTION_RATE.get());
+        int rate = opt != null && opt.isPresent() ? opt.get() : 0;
         if (rate == 0) {
             setConsumptionRate(DEFAULT_FUEL_CONSUMING_RATE);
             return DEFAULT_FUEL_CONSUMING_RATE;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataWarpingPlugin.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/plugins/AutomataWarpingPlugin.java
@@ -54,6 +54,13 @@ public class AutomataWarpingPlugin extends AutomataCorePlugin {
         return Pair.onlyRight(settings.get(POINT_DATA_MARK.get()));
     }
 
+    protected void setPointData(@NotNull CompoundTag data) {
+        TurtlePeripheralOwner owner = automataCore.getPeripheralOwner();
+        PatchedDataComponentMap settings = PatchedDataComponentMap.fromPatch(DataComponentMap.EMPTY, owner.getDataStorage());
+        settings.set(POINT_DATA_MARK.get(), data);
+        owner.putDataStorage(settings.asPatch());
+    }
+
     private int getWarpCost(SingleOperationContext context) {
         FuelAbility<?> fuelAbility = automataCore.getPeripheralOwner().getAbility(PeripheralOwnerAbility.FUEL);
         Objects.requireNonNull(fuelAbility);
@@ -72,6 +79,7 @@ public class AutomataWarpingPlugin extends AutomataCorePlugin {
             return MethodResult.of(null, "Cannot add new point, limit reached");
 
         data.put(name, NBTUtil.toNBT(automataCore.getPeripheralOwner().getPos()));
+        setPointData(data);
         return MethodResult.of(true);
     }
 
@@ -87,6 +95,7 @@ public class AutomataWarpingPlugin extends AutomataCorePlugin {
             return MethodResult.of(null, "Cannot find point to delete");
 
         data.remove(name);
+        setPointData(data);
         return MethodResult.of(true);
     }
 

--- a/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
@@ -311,6 +311,11 @@ public class APFakePlayer extends FakePlayer {
                 if (level().isEmptyBlock(blockPos) || blockPos.equals(blockPosition())) {
                     return null;
                 }
+                BlockHitResult shaped =  traceContext.getBlockShape(level().getBlockState(blockPos), level(), blockPos)
+                        .clip(rayTraceContext.getFrom(), rayTraceContext.getTo(), blockPos);
+                if (shaped != null && shaped.getType() != HitResult.Type.MISS) {
+                    return shaped;
+                }
                 return new BlockHitResult(new Vec3(blockPos.getX(), blockPos.getY(), blockPos.getZ()), traceDirection, blockPos, false);
             }, rayTraceContext -> BlockHitResult.miss(rayTraceContext.getTo(), traceDirection, new BlockPos((int) rayTraceContext.getTo().x, (int) rayTraceContext.getTo().y, (int) rayTraceContext.getTo().z)));
         }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/fakeplayer/APFakePlayer.java
@@ -311,7 +311,7 @@ public class APFakePlayer extends FakePlayer {
                 if (level().isEmptyBlock(blockPos) || blockPos.equals(blockPosition())) {
                     return null;
                 }
-                BlockHitResult shaped =  traceContext.getBlockShape(level().getBlockState(blockPos), level(), blockPos)
+                BlockHitResult shaped = traceContext.getBlockShape(level().getBlockState(blockPos), level(), blockPos)
                         .clip(rayTraceContext.getFrom(), rayTraceContext.getTo(), blockPos);
                 if (shaped != null && shaped.getType() != HitResult.Type.MISS) {
                     return shaped;


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
This fixes the following things:
1. [NullPointerException when using useOnBlock](https://github.com/IntelligenceModding/AdvancedPeripherals/commit/8fbe163e7d35964fd1957fd3be0efa4f7ff5e895)
2.  [not using the actual hit vector for block interactions](https://github.com/IntelligenceModding/AdvancedPeripherals/commit/056d269666624faeb0ade55ae111b2b2db1fa9c9)
3. [not saving warp points](https://github.com/IntelligenceModding/AdvancedPeripherals/pull/701/commits/2ed1cfec9497b914a91e5400767c5e38aa4e5060)

* **What is the current behavior?** (You can also link to an open issue here)
1. https://github.com/IntelligenceModding/AdvancedPeripherals/issues/699
2. It uses the block position in the hit result for interactions
3. not saving warp points

* **What is the new behavior (if this is a feature change)?**
2. If a block was hit calculate the actual hit vector and use this for the result.
    In case that fails fall back to the block position
3. save the compound tag after editing the points

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No

* **Other information**:

