### PR TITLE
fix BlockReader.getBlockData is not using correct registry access

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
@@ -7,7 +7,6 @@ import de.srendi.advancedperipherals.common.blocks.blockentities.BlockReaderEnti
 import de.srendi.advancedperipherals.common.configuration.APConfig;
 import de.srendi.advancedperipherals.common.util.LuaConverter;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/BlockReaderPeripheral.java
@@ -9,6 +9,7 @@ import de.srendi.advancedperipherals.common.util.LuaConverter;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -40,10 +41,11 @@ public class BlockReaderPeripheral extends BasePeripheral<BlockEntityPeripheralO
     public final Object getBlockData() {
         if (getBlockInFront().is(Blocks.AIR))
             return null;
-        BlockEntity target = getLevel().getBlockEntity(getPos().relative(owner.getFacing()));
+        Level level = getLevel();
+        BlockEntity target = level.getBlockEntity(getPos().relative(owner.getFacing()));
         if (target == null)
             return null;
-        return NBTUtil.toLua(target.saveWithoutMetadata(RegistryAccess.EMPTY));
+        return NBTUtil.toLua(target.saveWithoutMetadata(level.registryAccess()));
     }
 
     @LuaFunction(mainThread = true)


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
  - #710

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  No

* **Other information**:

