### PR TITLE
config type patch

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/APConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/APConfig.java
@@ -3,7 +3,6 @@ package de.srendi.advancedperipherals.common.configuration;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.config.ConfigFileTypeHandler;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
 
@@ -11,8 +10,6 @@ import java.nio.file.Path;
 import java.util.function.Function;
 
 public class APConfig extends ModConfig {
-
-    public static final ConfigFileHandler CONFIG_FILE_HANDLER = new ConfigFileHandler();
 
     public static final GeneralConfig GENERAL_CONFIG = new GeneralConfig();
     public static final PeripheralsConfig PERIPHERALS_CONFIG = new PeripheralsConfig();
@@ -24,37 +21,10 @@ public class APConfig extends ModConfig {
     }
 
     public static void register(ModLoadingContext context) {
-        //Creates the config folder
-        FMLPaths.getOrCreateGameRelativePath(FMLPaths.CONFIGDIR.get().resolve("Advancedperipherals"), "Advancedperipherals");
-
         ModContainer modContainer = context.getActiveContainer();
         modContainer.addConfig(new APConfig(GENERAL_CONFIG, modContainer));
         modContainer.addConfig(new APConfig(PERIPHERALS_CONFIG, modContainer));
         modContainer.addConfig(new APConfig(METAPHYSICS_CONFIG, modContainer));
         modContainer.addConfig(new APConfig(WORLD_CONFIG, modContainer));
-    }
-
-    @Override
-    public ConfigFileTypeHandler getHandler() {
-        return CONFIG_FILE_HANDLER;
-    }
-
-    public static class ConfigFileHandler extends ConfigFileTypeHandler {
-
-        public static Path getPath(Path path) {
-            if (path.endsWith("serverconfig")) return FMLPaths.CONFIGDIR.get();
-
-            return path;
-        }
-
-        @Override
-        public Function<ModConfig, CommentedFileConfig> reader(Path configBasePath) {
-            return super.reader(getPath(configBasePath));
-        }
-
-        @Override
-        public void unload(Path configBasePath, ModConfig config) {
-            super.unload(getPath(configBasePath), config);
-        }
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/APConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/APConfig.java
@@ -1,13 +1,8 @@
 package de.srendi.advancedperipherals.common.configuration;
 
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.loading.FMLPaths;
-
-import java.nio.file.Path;
-import java.util.function.Function;
 
 public class APConfig extends ModConfig {
 

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/GeneralConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/GeneralConfig.java
@@ -45,6 +45,6 @@ public class GeneralConfig implements IAPConfig {
 
     @Override
     public ModConfig.Type getType() {
-        return ModConfig.Type.COMMON;
+        return ModConfig.Type.SERVER;
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/MetaphysicsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/MetaphysicsConfig.java
@@ -47,6 +47,6 @@ public class MetaphysicsConfig implements IAPConfig {
 
     @Override
     public ModConfig.Type getType() {
-        return ModConfig.Type.COMMON;
+        return ModConfig.Type.SERVER;
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/PeripheralsConfig.java
@@ -268,7 +268,7 @@ public class PeripheralsConfig implements IAPConfig {
 
     @Override
     public ModConfig.Type getType() {
-        return ModConfig.Type.COMMON;
+        return ModConfig.Type.SERVER;
     }
 
     private List<Predicate<String>> parseChatBoxCommandFilters() {

--- a/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/configuration/WorldConfig.java
@@ -41,9 +41,6 @@ public class WorldConfig implements IAPConfig {
 
     @Override
     public ModConfig.Type getType() {
-        return ModConfig.Type.COMMON;
+        return ModConfig.Type.SERVER;
     }
-    /*
-    [
-     */
 }


### PR DESCRIPTION
- **change config type from common to server to allow each save has its own config values**
- **remove unused imports**

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  idk

* **What is the current behavior?** (You can also link to an open issue here)
  - #693

* **What is the new behavior (if this is a feature change)?**
  Config now will generate in `saves/<world name>/serverconfig/` instead of a global instance locate at `config/`.
  Server location also changed to `world/serverconfig/`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  Yes, people need copy their configs to the serverconfig folder if they want use same config for their world.

* **Other information**:
  https://github.com/IntelligenceModding/AdvancedPeripherals/pull/703#issuecomment-2605933668

