### PR TITLE
implement item&fluid handlers on bridges

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false
+org.gradle.jvmargs=-Xmx4G
 org.gradle.logging.level=info
 
 # Minecraft related
@@ -10,53 +10,57 @@ mod_id=advancedperipherals
 mod_version=0.8r
 minecraft_version=1.19.2
 mod_artifact_suffix=
+
 forge_version=43.4.0
 loader_version=43
+
 release_type=release
+
 mappings_channel=parchment
 mappings_version=2022.11.20-1.19.2
-jb_annotations=21.0.1
 
 # Test dependencies
-junit_version=5.7.2
 hamcrest_version=2.2
+jb_annotations=21.0.1
+junit_version=5.7.2
 kotlin_version=1.8.0
 kotlinx_coroutines_version=1.7.3
 ttoolkit_version=0.1.3
 
 # Mod dependencies
 cc_version=1.101.3
-curios_version=1.19.2-5.1.4.1
-minecolonies_version=1.19.2-1.1.473-BETA
-appliedenergistics_version=12.9.9
-patchouli_version=1.19.2-77
-refinedstorage_version=1.11.7
+
+ae2additions_version=4646599
+ae2things_version=4367610
+appliedenergistics_version=12.9.12
+appliedmekanistics_version=4734608
 botania_version=1.19.2-440-FORGE
+clockwork_version=5171528
 create_version=0.5.1.f-46
 createca_version=5099757
-mekanism_version=1.19.2-10.3.9.13
-ae2things_version=4367610
-powah_version=4183078
-ae2additions_version=4646599
-kotlinforforge_version=3.12.0
-appliedmekanistics_version=4734608
+curios_version=1.19.2-5.1.4.1
 dimstorage_version=3927875
-valkyrien_skies_version=4994898
 eureka_ships_version=5321628
-clockwork_version=5171528
+kotlinforforge_version=3.12.0
+mekanism_version=1.19.2-10.3.9.13
+minecolonies_version=1.19.2-1.1.473-BETA
+patchouli_version=1.19.2-77
+powah_version=4183078
+refinedstorage_version=1.11.7
+valkyrien_skies_version=4994898
 vs2_version=2.1.2-beta.1+a04911c932
 vs_core_version=1.1.0+2a62e6a823
 
 # Mod dependencies which are needed for other mods
 # For minecolonies
-structurize_version=1.19.2-1.0.649-BETA
-multipiston_version=1.19.2-1.2.21-ALPHA
 blockui_version=1.19.2-0.0.102-ALPHA
 domumornamentum_version=1.19-1.0.141-BETA
+multipiston_version=1.19.2-1.2.21-ALPHA
+structurize_version=1.19.2-1.0.649-BETA
 
 # For DimStorage
 edivadlib_version=3927847
 
-# Mod dependencies for testing stuff(Only used in the dev environment)
-jei_version=1.19.2-forge:11.6.0.1016
+# Mod dependencies for testing stuff (Only used in the dev environment)
 jade_version=4914105
+jei_version=1.19.2-forge:11.6.0.1016

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MeBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MeBridgePeripheral.java
@@ -33,6 +33,10 @@ import de.srendi.advancedperipherals.common.util.inventory.InventoryUtil;
 import de.srendi.advancedperipherals.common.util.inventory.ItemFilter;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import net.minecraft.core.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
@@ -50,6 +54,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     public static final String PERIPHERAL_TYPE = "me_bridge";
 
     private final MeBridgeEntity bridge;
+    private final ICapabilityProvider capabilityWrapper = new CapabilityWrapper(this);
     private IGridNode node;
 
     public MeBridgePeripheral(MeBridgeEntity tileEntity) {
@@ -63,12 +68,25 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     @Override
+    public Object getTarget() {
+        return capabilityWrapper;
+    }
+
+    @Override
     public boolean isEnabled() {
         return APConfig.PERIPHERALS_CONFIG.enableMEBridge.get();
     }
 
     private ICraftingService getCraftingService() {
         return node.getGrid().getCraftingService();
+    }
+
+    protected MeItemHandler getItemHandler() {
+        return new MeItemHandler(AppEngApi.getMonitor(node), bridge);
+    }
+
+    protected MeFluidHandler getFluidHandler() {
+        return new MeFluidHandler(AppEngApi.getMonitor(node), bridge);
     }
 
     /**
@@ -79,8 +97,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
      * @return the exportable amount or null with a string if something went wrong
      */
     protected MethodResult exportToChest(@NotNull IArguments arguments, @Nullable IItemHandler targetInventory) throws LuaException {
-        MEStorage monitor = AppEngApi.getMonitor(node);
-        MeItemHandler itemHandler = new MeItemHandler(monitor, bridge);
+        MeItemHandler itemHandler = getItemHandler();
         Pair<ItemFilter, String> filter = ItemFilter.parse(arguments.getTable(0));
 
         if (filter.rightPresent())
@@ -100,8 +117,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
      * @return the exportable amount or null with a string if something went wrong
      */
     protected MethodResult exportToTank(@NotNull IArguments arguments, @Nullable IFluidHandler targetTank) throws LuaException {
-        MEStorage monitor = AppEngApi.getMonitor(node);
-        MeFluidHandler fluidHandler = new MeFluidHandler(monitor, bridge);
+        MeFluidHandler fluidHandler = getFluidHandler();
         Pair<FluidFilter, String> filter = FluidFilter.parse(arguments.getTable(0));
 
         if (filter.rightPresent())
@@ -121,8 +137,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
      * @return the imported amount or null with a string if something went wrong
      */
     protected MethodResult importToME(@NotNull IArguments arguments, @Nullable IItemHandler targetInventory) throws LuaException {
-        MEStorage monitor = AppEngApi.getMonitor(node);
-        MeItemHandler itemHandler = new MeItemHandler(monitor, bridge);
+        MeItemHandler itemHandler = getItemHandler();
         Pair<ItemFilter, String> filter = ItemFilter.parse(arguments.getTable(0));
 
         if (filter.rightPresent())
@@ -142,8 +157,7 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
      * @return the imported amount or null with a string if something went wrong
      */
     protected MethodResult importToME(@NotNull IArguments arguments, @Nullable IFluidHandler targetTank) throws LuaException {
-        MEStorage monitor = AppEngApi.getMonitor(node);
-        MeFluidHandler fluidHandler = new MeFluidHandler(monitor, bridge);
+        MeFluidHandler fluidHandler = getFluidHandler();
         Pair<FluidFilter, String> filter = FluidFilter.parse(arguments.getTable(0));
 
         if (filter.rightPresent())
@@ -787,5 +801,23 @@ public class MeBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             map.add(cpu);
         }
         return MethodResult.of(map);
+    }
+
+    private static final class CapabilityWrapper implements ICapabilityProvider {
+        private final MeBridgePeripheral peripheral;
+
+        private CapabilityWrapper(MeBridgePeripheral peripheral) {
+            this.peripheral = peripheral;
+        }
+
+        @Override
+        public <T> LazyOptional<T> getCapability(final Capability<T> cap, final Direction side) {
+            if (cap == ForgeCapabilities.ITEM_HANDLER) {
+                return LazyOptional.of(this.peripheral::getItemHandler).cast();
+            } else if (cap == ForgeCapabilities.FLUID_HANDLER) {
+                return LazyOptional.of(this.peripheral::getFluidHandler).cast();
+            }
+            return LazyOptional.empty();
+        }
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RsBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/RsBridgePeripheral.java
@@ -29,6 +29,10 @@ import de.srendi.advancedperipherals.common.util.inventory.ItemFilter;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -46,6 +50,7 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     public static final String PERIPHERAL_TYPE = "rs_bridge";
 
     private final RsBridgeEntity bridge;
+    private final ICapabilityProvider capabilityWrapper = new CapabilityWrapper(this);
 
     public RsBridgePeripheral(RsBridgeEntity tileEntity) {
         super(PERIPHERAL_TYPE, new BlockEntityPeripheralOwner<>(tileEntity));
@@ -69,8 +74,21 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     @Override
+    public Object getTarget() {
+        return capabilityWrapper;
+    }
+
+    @Override
     public boolean isEnabled() {
         return APConfig.PERIPHERALS_CONFIG.enableRSBridge.get();
+    }
+
+    protected RsItemHandler getItemHandler() {
+        return new RsItemHandler(getNetwork());
+    }
+
+    protected RsFluidHandler getFluidHandler() {
+        return new RsFluidHandler(getNetwork());
     }
 
     @Override
@@ -393,7 +411,7 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     protected MethodResult exportToChest(@NotNull IArguments arguments, @Nullable IItemHandler targetInventory) throws LuaException {
-        RsItemHandler itemHandler = new RsItemHandler(getNetwork());
+        RsItemHandler itemHandler = getItemHandler();
         if (targetInventory == null)
             return MethodResult.of(0, "INVALID_TARGET");
 
@@ -405,7 +423,7 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     protected MethodResult importToSystem(@NotNull IArguments arguments, @Nullable IItemHandler targetInventory) throws LuaException {
-        RsItemHandler itemHandler = new RsItemHandler(getNetwork());
+        RsItemHandler itemHandler = getItemHandler();
         if (targetInventory == null)
             return MethodResult.of(0, "INVALID_TARGET");
 
@@ -417,7 +435,7 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     protected MethodResult exportToTank(@NotNull IArguments arguments, @Nullable IFluidHandler targetInventory) throws LuaException {
-        RsFluidHandler itemHandler = new RsFluidHandler(getNetwork());
+        RsFluidHandler itemHandler = getFluidHandler();
         if (targetInventory == null)
             return MethodResult.of(0, "INVALID_TARGET");
 
@@ -429,7 +447,7 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
     }
 
     protected MethodResult importToSystem(@NotNull IArguments arguments, @Nullable IFluidHandler targetInventory) throws LuaException {
-        RsFluidHandler itemHandler = new RsFluidHandler(getNetwork());
+        RsFluidHandler itemHandler = getFluidHandler();
         if (targetInventory == null)
             return MethodResult.of(0, "INVALID_TARGET");
 
@@ -713,5 +731,23 @@ public class RsBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
         GenericFilter<?> parsedFilter = filter.getLeft();
 
         return MethodResult.of(RsApi.findPatternFromFilters(getNetwork(), null, parsedFilter).getLeft() != null);
+    }
+
+    private static final class CapabilityWrapper implements ICapabilityProvider {
+        private final RsBridgePeripheral peripheral;
+
+        private CapabilityWrapper(RsBridgePeripheral peripheral) {
+            this.peripheral = peripheral;
+        }
+
+        @Override
+        public <T> LazyOptional<T> getCapability(final Capability<T> cap, final Direction side) {
+            if (cap == ForgeCapabilities.ITEM_HANDLER) {
+                return LazyOptional.of(this.peripheral::getItemHandler).cast();
+            } else if (cap == ForgeCapabilities.FLUID_HANDLER) {
+                return LazyOptional.of(this.peripheral::getFluidHandler).cast();
+            }
+            return LazyOptional.empty();
+        }
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/FluidFilter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/FluidFilter.java
@@ -27,7 +27,7 @@ public class FluidFilter extends GenericFilter<FluidStack> {
     private TagKey<Fluid> tag = null;
     private CompoundTag nbt = null;
     private String nbtHash = null;
-    private int count = 1000;
+    private int count = Integer.MAX_VALUE;
     private String fingerprint = "";
 
     private FluidFilter() {

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
@@ -52,6 +52,11 @@ public class InventoryUtil {
 
         // The logic changes with storage systems since these systems do not have slots
         if (inventoryFrom instanceof IStorageSystemItemHandler storageSystemHandler) {
+            if (inventoryTo instanceof IStorageSystemItemHandler targetSSH) {
+                ItemStack extracted = storageSystemHandler.extractItem(filter, filter.getCount(), true);
+                ItemStack remain = targetSSH.insertItem(toSlot, extracted, false);
+                return storageSystemHandler.extractItem(filter, extracted.getCount() - remain.getCount(), false).getCount();
+            }
             for (int i = toSlot == -1 ? 0 : toSlot; i < (toSlot == -1 ? inventoryTo.getSlots() : toSlot + 1); i++) {
                 ItemStack extracted = storageSystemHandler.extractItem(filter, filter.getCount(), true);
                 if (extracted.isEmpty())

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ItemFilter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ItemFilter.java
@@ -27,7 +27,7 @@ public class ItemFilter extends GenericFilter<ItemStack> {
     private TagKey<Item> tag = null;
     private CompoundTag nbt = null;
     private String nbtHash = null;
-    private int count = 64;
+    private int count = Integer.MAX_VALUE;
     private String fingerprint = "";
     public int fromSlot = -1;
     public int toSlot = -1;


### PR DESCRIPTION
- **update gradle.properties**
- **implement ICapabilityProvider on MeBridgePeripheral close IntelligenceModding/Advanced-Peripherals-Features#77**
- **implement ICapabilityProvider on rsbridge**
- **make itemfilter default count as max integer so people can export/import all items when the count is not provided**

**PLEASE READ THE [GUIDELINES](https://github.com/SirEndii/AdvancedPeripherals/blob/dev/1.20.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/SirEndii/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
  Feature

* **What is the new behavior (if this is a feature change)?**
  People can invoke `[export|import][Item|Fluid]` on other bridge peripherals, or invoke `[pull|push][Item|Fluid]` on bridges from normal inventories.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
  The default item filter count changed from 64 to infinity (max integer)
  The default fluid filter count changed from 1000 to infinity (max integer)

* **Other information**:

