### PR TITLE
Fix bug in `import*` and `export*` functions in `MEBridgePeripheral` not detecting any remote inventory peripherals.

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MEBridgePeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/MEBridgePeripheral.java
@@ -15,7 +15,6 @@ import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.core.apis.TableHelper;
-import dan200.computercraft.core.computer.ComputerSide;
 import de.srendi.advancedperipherals.common.addons.APAddon;
 import de.srendi.advancedperipherals.common.addons.appliedenergistics.AEApi;
 import de.srendi.advancedperipherals.common.addons.appliedenergistics.AECraftJob;
@@ -38,7 +37,6 @@ import de.srendi.advancedperipherals.common.util.inventory.ItemFilter;
 import de.srendi.advancedperipherals.lib.peripherals.BasePeripheral;
 import me.ramidzkh.mekae2.ae2.MekanismKey;
 import mekanism.api.chemical.IChemicalHandler;
-import net.minecraft.core.Direction;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +45,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwner<MEBridgeEntity>> implements IStorageSystemPeripheral {
@@ -376,12 +373,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return notConnected(0);
 
         String side = arguments.getString(1);
-        IItemHandler inventory;
+        IItemHandler inventory = InventoryUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            inventory = InventoryUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            inventory = InventoryUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (inventory == null) {
+            inventory = InventoryUtil.getHandlerFromName(computer, side);
         }
 
         if (inventory == null)
@@ -397,12 +392,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return notConnected(0);
 
         String side = arguments.getString(1);
-        IItemHandler inventory;
+        IItemHandler inventory = InventoryUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            inventory = InventoryUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            inventory = InventoryUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (inventory == null) {
+            inventory = InventoryUtil.getHandlerFromName(computer, side);
         }
 
         if (inventory == null)
@@ -418,12 +411,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return notConnected(0);
 
         String side = arguments.getString(1);
-        IFluidHandler fluidHandler;
+        IFluidHandler fluidHandler = FluidUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            fluidHandler = FluidUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            fluidHandler = FluidUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (fluidHandler == null) {
+            fluidHandler = FluidUtil.getHandlerFromName(computer, side);
         }
 
         if (fluidHandler == null)
@@ -439,12 +430,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return notConnected(0);
 
         String side = arguments.getString(1);
-        IFluidHandler fluidHandler;
+        IFluidHandler fluidHandler = FluidUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            fluidHandler = FluidUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            fluidHandler = FluidUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (fluidHandler == null) {
+            fluidHandler = FluidUtil.getHandlerFromName(computer, side);
         }
 
         if (fluidHandler == null)
@@ -464,12 +453,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return MethodResult.of(0);
 
         String side = arguments.getString(1);
-        IChemicalHandler chemicalHandler;
+        IChemicalHandler chemicalHandler = ChemicalUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            chemicalHandler = ChemicalUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            chemicalHandler = ChemicalUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (chemicalHandler == null) {
+            chemicalHandler = ChemicalUtil.getHandlerFromName(computer, side);
         }
 
         if (chemicalHandler == null)
@@ -488,12 +475,10 @@ public class MEBridgePeripheral extends BasePeripheral<BlockEntityPeripheralOwne
             return MethodResult.of(0);
 
         String side = arguments.getString(1);
-        IChemicalHandler chemicalHandler;
+        IChemicalHandler chemicalHandler = ChemicalUtil.getHandlerFromDirection(side, owner);
 
-        if (Direction.byName(side.toUpperCase(Locale.ROOT)) == null && ComputerSide.valueOfInsensitive(side.toUpperCase(Locale.ROOT)) == null) {
-            chemicalHandler = ChemicalUtil.getHandlerFromDirection(arguments.getString(1), owner);
-        } else {
-            chemicalHandler = ChemicalUtil.getHandlerFromName(computer, arguments.getString(1));
+        if (chemicalHandler == null) {
+            chemicalHandler = ChemicalUtil.getHandlerFromName(computer, side);
         }
 
         if (chemicalHandler == null)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Unable to import anything from any remote inventory peripherals to ME storage
Unable to export anything from ME storage to any remote inventory peripherals

* **What is the new behavior (if this is a feature change)?**
Able to import item/fluid/chemical from any remote inventory peripherals to ME storage
Able to export item/fluid/chemical from ME storage to any remote inventory peripherals

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
For those who relied on the current behavior, yes

* **Other information**:
Before patch:
![2025-06-14_20 42 08](https://github.com/user-attachments/assets/d69a1bf9-ff5c-4611-914c-115ada8e66f2)
