### PR TITLE
add utf8 message support to chatboxes

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -172,43 +172,43 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String message = arguments.getString(0);
 
             // check size while it represents bytes (in utf8 mode) as that is longer
-          if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
-            return MethodResult.of(null, "Message is too long");
-          }
+            if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
+                return MethodResult.of(null, "Message is too long");
+            }
 
-          if (useUTF8) {
-            message = StringUtil.byteStringToUTF8(message);
-          }
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
 
-          int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-          int range = arguments.optInt(4, -1);
-          ResourceKey<Level> dimension = getLevel().dimension();
+            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
+            int range = arguments.optInt(4, -1);
+            ResourceKey<Level> dimension = getLevel().dimension();
 
-          Optional<String> brackets = arguments.optString(2);
-          if (useUTF8) {
-              brackets = brackets.map(StringUtil::byteStringToUTF8);
-          }
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
 
-          if (checkBrackets(brackets))
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
-          Optional<String> prefix = arguments.optString(1);
-          if (useUTF8) {
-              prefix = prefix.map(StringUtil::byteStringToUTF8);
-          }
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
 
-          String bracketColor = arguments.optString(3, "");
-          if (useUTF8) {
-              bracketColor = StringUtil.byteStringToUTF8(bracketColor);
-          }
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
 
-          MutableComponent preparedMessage = appendPrefix(
+            MutableComponent preparedMessage = appendPrefix(
                     StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
                     brackets.orElse("[]"),
                     StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
 
-          for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
+            for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                     continue;
                 if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
@@ -231,7 +231,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "Message is too long");
 
             if (useUTF8) {
-              message = StringUtil.byteStringToUTF8(message);
+                message = StringUtil.byteStringToUTF8(message);
             }
 
 
@@ -289,23 +289,23 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             boolean useUTF8 = arguments.optBoolean(7, false);
 
             String message = arguments.getString(0);
-          // check size while it represents bytes (in utf8 mode) as that is longer
-          if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
-            return MethodResult.of(null, "Message is too long");
-          }
+            // check size while it represents bytes (in utf8 mode) as that is longer
+            if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
+                return MethodResult.of(null, "Message is too long");
+            }
 
-          if (useUTF8) {
-            message = StringUtil.byteStringToUTF8(message);
-          }
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
 
 
-          String title = arguments.getString(1);
+            String title = arguments.getString(1);
 
-          // TODO: missing max length check?
+            // TODO: missing max length check?
 
-          if (useUTF8) {
-            title = StringUtil.byteStringToUTF8(title);
-          }
+            if (useUTF8) {
+                title = StringUtil.byteStringToUTF8(title);
+            }
 
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
@@ -326,14 +326,14 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             Optional<String> brackets = arguments.optString(4);
 
             if (useUTF8) {
-              brackets = brackets.map(StringUtil::byteStringToUTF8);
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
             }
 
-          if (checkBrackets(brackets))
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ,,,)");
 
 
-          Optional<String> prefix = arguments.optString(3);
+            Optional<String> prefix = arguments.optString(3);
             if (useUTF8) {
                 prefix = prefix.map(StringUtil::byteStringToUTF8);
             }
@@ -386,26 +386,26 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-          Optional<String> brackets = arguments.optString(3);
+            Optional<String> brackets = arguments.optString(3);
 
-          if (useUTF8) {
-            brackets = brackets.map(StringUtil::byteStringToUTF8);
-          }
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
 
-          if (checkBrackets(brackets))
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
-          Optional<String> prefix = arguments.optString(2);
+            Optional<String> prefix = arguments.optString(2);
 
-          if (useUTF8) {
-            prefix = prefix.map(StringUtil::byteStringToUTF8);
-          }
-          String bracketColor = arguments.optString(4, "");
-          if (useUTF8) {
-            bracketColor = StringUtil.byteStringToUTF8(bracketColor);
-          }
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
 
-          MutableComponent preparedMessage = appendPrefix(
+            MutableComponent preparedMessage = appendPrefix(
                     StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
                     brackets.orElse("[]"),
                     StringUtil.convertAndToSectionMark(bracketColor)
@@ -452,25 +452,25 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-          Optional<String> brackets = arguments.optString(4);
+            Optional<String> brackets = arguments.optString(4);
 
-          if (useUTF8) {
-            brackets = brackets.map(StringUtil::byteStringToUTF8);
-          }
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
 
-          if (checkBrackets(brackets))
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
-          Optional<String> prefix = arguments.optString(3);
+            Optional<String> prefix = arguments.optString(3);
 
-          if (useUTF8) {
-            prefix = prefix.map(StringUtil::byteStringToUTF8);
-          }
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
 
-          String bracketColor = arguments.optString(5, "");
-          if (useUTF8) {
-            bracketColor = StringUtil.byteStringToUTF8(bracketColor);
-          }
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
 
             MutableComponent preparedMessage = appendPrefix(
                     StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
@@ -491,10 +491,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public void update() {
         lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> {
-          String byteString = StringUtil.utf8ToByteString(message.message());
-          for (IComputerAccess computer : getConnectedComputers()) {
-              computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(),
-                  byteString);
+            String byteString = StringUtil.utf8ToByteString(message.message());
+            for (IComputerAccess computer : getConnectedComputers()) {
+                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(),
+                        byteString);
             }
         });
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -107,13 +107,21 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return brackets.isPresent() && brackets.get().length() != 2;
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
 
+            // check size while it represents bytes (in utf8 mode) as that is longer
             if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
                 return MethodResult.of(null, "Message is too long");
+
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
 
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
@@ -122,13 +130,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (component == null)
                 return MethodResult.of(null, "incorrect json");
 
-            if (checkBrackets(arguments.optString(2)))
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(component);
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -140,26 +163,52 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
 
-            if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
-                return MethodResult.of(null, "Message is too long");
+            // check size while it represents bytes (in utf8 mode) as that is longer
+          if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
+            return MethodResult.of(null, "Message is too long");
+          }
 
-            int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
-            int range = arguments.optInt(4, -1);
-            ResourceKey<Level> dimension = getLevel().dimension();
-            if (checkBrackets(arguments.optString(2)))
+          if (useUTF8) {
+            message = StringUtil.byteStringToUTF8(message);
+          }
+
+          int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
+          int range = arguments.optInt(4, -1);
+          ResourceKey<Level> dimension = getLevel().dimension();
+
+          Optional<String> brackets = arguments.optString(2);
+          if (useUTF8) {
+              brackets = brackets.map(StringUtil::byteStringToUTF8);
+          }
+
+          if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
-            MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+          Optional<String> prefix = arguments.optString(1);
+          if (useUTF8) {
+              prefix = prefix.map(StringUtil::byteStringToUTF8);
+          }
+
+          String bracketColor = arguments.optString(3, "");
+          if (useUTF8) {
+              bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+          }
+
+          MutableComponent preparedMessage = appendPrefix(
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
-            for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
+
+          for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                     continue;
                 if (CoordUtil.isInRange(getPos(), getLevel(), player, range, maxRange))
@@ -169,13 +218,22 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 color, 5 range
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
 
+            // check size while it represents bytes (in utf8 mode) as that is longer
             if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
                 return MethodResult.of(null, "Message is too long");
+
+            if (useUTF8) {
+              message = StringUtil.byteStringToUTF8(message);
+            }
+
 
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
@@ -189,14 +247,31 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (component == null)
                 return MethodResult.of(null, "incorrect json");
 
-            if (checkBrackets(arguments.optString(3)))
+            Optional<String> brackets = arguments.optString(3);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(2);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(component);
+
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
 
@@ -207,15 +282,31 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
     }
 
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
+          // check size while it represents bytes (in utf8 mode) as that is longer
+          if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get()) {
+            return MethodResult.of(null, "Message is too long");
+          }
 
-            if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
-                return MethodResult.of(null, "Message is too long");
+          if (useUTF8) {
+            message = StringUtil.byteStringToUTF8(message);
+          }
 
-            String title = arguments.getString(1);
+
+          String title = arguments.getString(1);
+
+          // TODO: missing max length check?
+
+          if (useUTF8) {
+            title = StringUtil.byteStringToUTF8(title);
+          }
+
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -232,13 +323,31 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (titleComponent == null)
                 return MethodResult.of(null, "incorrect json for title");
 
-            if (checkBrackets(arguments.optString(4)))
+            Optional<String> brackets = arguments.optString(4);
+
+            if (useUTF8) {
+              brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+          if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ,,,)");
 
+
+          Optional<String> prefix = arguments.optString(3);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(messageComponent);
 
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -253,13 +362,21 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 bracket color, 5 range, 6 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(6, false);
+
             String message = arguments.getString(0);
 
+            // check size while it represents bytes (in utf8 mode) as that is longer
             if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
                 return MethodResult.of(null, "Message is too long");
+
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
 
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
@@ -269,13 +386,29 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-            if (checkBrackets(arguments.optString(3)))
+          Optional<String> brackets = arguments.optString(3);
+
+          if (useUTF8) {
+            brackets = brackets.map(StringUtil::byteStringToUTF8);
+          }
+
+          if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
-            MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+          Optional<String> prefix = arguments.optString(2);
+
+          if (useUTF8) {
+            prefix = prefix.map(StringUtil::byteStringToUTF8);
+          }
+          String bracketColor = arguments.optString(4, "");
+          if (useUTF8) {
+            bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+          }
+
+          MutableComponent preparedMessage = appendPrefix(
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
@@ -286,15 +419,31 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
 
             if (message.length() > APConfig.PERIPHERALS_CONFIG.chatBoxMessageSize.get())
                 return MethodResult.of(null, "Message is too long");
 
+            // check size while it represents bytes (in utf8 mode) as that is longer
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String title = arguments.getString(1);
+
+            // TODO: missing max length check?
+
+            if (useUTF8) {
+                title = StringUtil.byteStringToUTF8(title);
+            }
+
+
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -303,13 +452,30 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-            if (checkBrackets(arguments.optString(4)))
+          Optional<String> brackets = arguments.optString(4);
+
+          if (useUTF8) {
+            brackets = brackets.map(StringUtil::byteStringToUTF8);
+          }
+
+          if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+          Optional<String> prefix = arguments.optString(3);
+
+          if (useUTF8) {
+            prefix = prefix.map(StringUtil::byteStringToUTF8);
+          }
+
+          String bracketColor = arguments.optString(5, "");
+          if (useUTF8) {
+            bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+          }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
 
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -325,8 +491,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public void update() {
         lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> {
-            for (IComputerAccess computer : getConnectedComputers()) {
-                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden());
+          String byteString = StringUtil.utf8ToByteString(message.message());
+          for (IComputerAccess computer : getConnectedComputers()) {
+              computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(),
+                  byteString);
             }
         });
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
@@ -18,17 +18,17 @@ public class StringUtil {
     /**
      * This method will convert "&[0-9a-z]" to "§[0-9a-z]", then we can make colored message in CC easier
      * If a '&' is behind reverse slash '\', it will be ignored.
-     *   Note: In CC, you need to use <code>"\\&"</code> to get an unescaped '&' character
+     * Note: In CC, you need to use <code>"\\&"</code> to get an unescaped '&' character
      * If the character after '&' is not a digital number or lowercase letter, the & operator will not be escaped as well.
      *
      * Some convert example:
-     *  "&a" -> "§a"
-     *  "&" -> "&"
-     *  "\\&" -> "&"
-     *  "\\&a" -> "&a"
-     *  "&A" -> "&A"
-     *  "& a" -> "& a"
-     *  "&&a" -> "&§a"
+     * "&a" -> "§a"
+     * "&" -> "&"
+     * "\\&" -> "&"
+     * "\\&a" -> "&a"
+     * "&A" -> "&A"
+     * "& a" -> "& a"
+     * "&&a" -> "&§a"
      */
     public static String convertAndToSectionMark(String str) {
         return str == null ? null : str.replaceAll("(?<!\\\\)&(?=[0-9a-z])", "\u00a7").replaceAll("\\\\&", "&");
@@ -40,7 +40,6 @@ public class StringUtil {
      * Lua encodes bytes as 8bit ASCII (latin1) strings.
      * To convert this to a UTF-8 string, we need to interpret the byte string as ISO-8859-1 to get each individual byte,
      * then convert that to a UTF-8 string.
-     *
      *
      * @param asciiByteString the utf encoded string sourced from lua.
      * @return A String, with all characters correctly interpreted as UTF-8.

--- a/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
@@ -1,5 +1,7 @@
 package de.srendi.advancedperipherals.common.util;
 
+import java.nio.charset.StandardCharsets;
+
 public class StringUtil {
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
@@ -30,5 +32,34 @@ public class StringUtil {
      */
     public static String convertAndToSectionMark(String str) {
         return str == null ? null : str.replaceAll("(?<!\\\\)&(?=[0-9a-z])", "\u00a7").replaceAll("\\\\&", "&");
+    }
+
+    /**
+     * Converts from a lua-sourced byte string to a UTF-8 string.
+     * </p>
+     * Lua encodes bytes as 8bit ASCII (latin1) strings.
+     * To convert this to a UTF-8 string, we need to interpret the byte string as ISO-8859-1 to get each individual byte,
+     * then convert that to a UTF-8 string.
+     *
+     *
+     * @param asciiByteString the utf encoded string sourced from lua.
+     * @return A String, with all characters correctly interpreted as UTF-8.
+     */
+    public static String byteStringToUTF8(String asciiByteString) {
+        return new String(asciiByteString.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Converts from a UTF-8 string to a lua-sourced byte string.
+     * </p>
+     * Lua enforces that all characters in any string passed to it are valid latin1 characters (0-255)
+     * </p>
+     * to get around this, we first convert the UTF-8 string to bytes, which are interpreted as characters seperately.
+     *
+     * @param utf8String the utf encoded string sourced from lua.
+     * @return a string, with all multibyte sequence characters split into their individual byte characters.
+     */
+    public static String utf8ToByteString(String utf8String) {
+        return new String(utf8String.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
     }
 }


### PR DESCRIPTION
adds optional "useUtf8" parameter, informing us that the program is utf8 aware, providing its strings as utf8, This allows sending messages in the extended minecraft character set.

see the utf8 lib in cc, as well as the \u{xxxx} escape sequence.

also sends the events with a new utf8 message parameter.

**PLEASE READ THE [GUIDELINES](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/dev/1.21.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [X] The commit message are well described
- [ ] Docs have been added / updated (for features or maybe bugs which were noted). If not, please update the needed documentation [here](https://github.com/IntelligenceModding/Advanced-Peripherals-Documentation/pulls). Feel free to remove this check if you don't need it (will todo tmr)
- [ ] All changes have fully been tested (TODO, test other functions, formatted/toast)

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
![image](https://github.com/user-attachments/assets/c1f71be6-0caf-450f-ae79-ec2904409240)


* **What is the new behavior (if this is a feature change)?**
![image](https://github.com/user-attachments/assets/3ed14d38-e8fe-45af-8f34-74b3b8dcca0f)

utf8 message is provided as argument 5 (the current last one)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
NO: this behaviour is opt in as a default-false optional parameter to all messagebox methods.
if users with to take advantage of this behaviour when sending messages, they should set the (current) last parameter to true
unless they are relying on specific parameter counts / not having extra data in the event, but thats not a breaking change for 99%, just 1 case of [spacebar heating](https://xkcd.com/1172/)

