### PR TITLE
backport port chatbox utf8 support to 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,8 +213,6 @@ repositories {
         name = "Create maven"
         url = "https://maven.tterrag.com/"
         content {
-            includeGroup("com.simibubi.create")
-            includeGroup("com.jozufozu.flywheel")
             includeGroup("com.tterrag.registrate")
         }
     }
@@ -325,8 +323,8 @@ dependencies {
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 
     // Create
-    compileOnly fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:all")
-    runtimeOnly fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:all")
+    compileOnly fg.deobf("curse.maven:create-328085:${create_version}")
+    runtimeOnly fg.deobf("curse.maven:create-328085:${create_version}")
 
     //Removed until fully ported
     //testImplementation fg.deobf("site.siredvin.ttoolkit:ttoolkit-${minecraft_version}:${ttoolkit_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,8 @@ appliedenergistics_version=12.9.5
 patchouli_version=1.19.2-77
 refinedstorage_version=1.11.6
 botania_version=1.19.2-440-FORGE
-create_version=0.5.1.f-46
+#Create 1.19.2 v0.5.1f
+create_version=4835190
 createca_version=5099757
 mekanism_version=1.19.2-10.3.9.13
 ae2things_version=4367610

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -24,7 +24,12 @@ import de.srendi.advancedperipherals.lib.peripherals.IPeripheralFunction;
 import de.srendi.advancedperipherals.network.APNetworking;
 import de.srendi.advancedperipherals.network.toclient.ToastToClientPacket;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.*;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentContents;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.TooltipFlag;
@@ -110,15 +115,15 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         if (click != null) {
             if (isChatBoxPreventingRunCommand() && click.getAction() == ClickEvent.Action.RUN_COMMAND) {
                 style = style
-                        .withClickEvent(null)
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("'run_command' action is banned")));
+                    .withClickEvent(null)
+                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("'run_command' action is banned")));
             } else if (click.getAction() == ClickEvent.Action.RUN_COMMAND || click.getAction() == ClickEvent.Action.SUGGEST_COMMAND) {
                 String command = click.getValue();
                 if (command.length() > 0 && command.charAt(0) == '/') {
                     if (isCommandBanned(command)) {
                         style = style
-                                .withClickEvent(null)
-                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("Command `" + command + "` is banned")));
+                            .withClickEvent(null)
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("Command `" + command + "` is banned")));
                     } else if (shouldWrapCommand(command)) {
                         style = style.withClickEvent(new ClickEvent(click.getAction(), "/" + ROOT_SAFE_EXEC_LITERAL + " " + command));
                     }
@@ -243,9 +248,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -255,10 +260,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             if (
-                    APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
-                            && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
-                            && maxRange == -1
-                            && range == -1
+                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                    && maxRange == -1
+                    && range == -1
             ) {
                 ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
                 return MethodResult.of(true);
@@ -309,9 +314,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -321,10 +326,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             if (
-                    APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
-                            && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
-                            && maxRange == -1
-                            && range == -1
+                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                    && maxRange == -1
+                    && range == -1
             ) {
                 ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
                 return MethodResult.of(true);
@@ -392,9 +397,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -474,9 +479,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -536,9 +541,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -600,9 +605,9 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             }
 
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
-                    brackets.orElse("[]"),
-                    StringUtil.convertAndToSectionMark(bracketColor)
+                StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                brackets.orElse("[]"),
+                StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -626,7 +631,7 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             String byteString = StringUtil.utf8ToByteString(message.message());
             for (IComputerAccess computer : getConnectedComputers()) {
                 computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(),
-                        byteString);
+                    byteString);
             }
         });
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -24,18 +24,12 @@ import de.srendi.advancedperipherals.lib.peripherals.IPeripheralFunction;
 import de.srendi.advancedperipherals.network.APNetworking;
 import de.srendi.advancedperipherals.network.toclient.ToastToClientPacket;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentContents;
-import net.minecraft.network.chat.ClickEvent;
-import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.*;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.server.ServerLifecycleHooks;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,8 +38,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 
-import static de.srendi.advancedperipherals.common.commands.APCommands.ROOT_SAFE_EXEC_LITERAL;
 import static de.srendi.advancedperipherals.common.addons.computercraft.operations.SimpleFreeOperation.CHAT_MESSAGE;
+import static de.srendi.advancedperipherals.common.commands.APCommands.ROOT_SAFE_EXEC_LITERAL;
 
 public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
@@ -69,6 +63,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public ChatBoxPeripheral(IPocketAccess pocket) {
         this(new PocketPeripheralOwner(pocket));
+    }
+
+    private static MutableComponent createFormattedError(String message) {
+        return Component.literal("[AP] " + message).setStyle(Style.EMPTY.withColor(ChatFormatting.RED).withBold(true));
     }
 
     @Override
@@ -106,25 +104,21 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return false;
     }
 
-    private static MutableComponent createFormattedError(String message) {
-        return Component.literal("[AP] " + message).setStyle(Style.EMPTY.withColor(ChatFormatting.RED).withBold(true));
-    }
-
     @Nullable
     protected Style filterComponentStyle(@NotNull Style style) {
         ClickEvent click = style.getClickEvent();
         if (click != null) {
             if (isChatBoxPreventingRunCommand() && click.getAction() == ClickEvent.Action.RUN_COMMAND) {
                 style = style
-                    .withClickEvent(null)
-                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("'run_command' action is banned")));
+                        .withClickEvent(null)
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("'run_command' action is banned")));
             } else if (click.getAction() == ClickEvent.Action.RUN_COMMAND || click.getAction() == ClickEvent.Action.SUGGEST_COMMAND) {
                 String command = click.getValue();
                 if (command.length() > 0 && command.charAt(0) == '/') {
                     if (isCommandBanned(command)) {
                         style = style
-                            .withClickEvent(null)
-                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("Command `" + command + "` is banned")));
+                                .withClickEvent(null)
+                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createFormattedError("Command `" + command + "` is banned")));
                     } else if (shouldWrapCommand(command)) {
                         style = style.withClickEvent(new ClickEvent(click.getAction(), "/" + ROOT_SAFE_EXEC_LITERAL + " " + command));
                     }
@@ -207,10 +201,18 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return brackets.isPresent() && brackets.get().length() != 2;
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
+
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             ResourceKey<Level> dimension = getLevel().dimension();
             MutableComponent component = Component.Serializer.fromJson(message);
             if (component == null) {
@@ -221,14 +223,29 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "illegal message");
             }
 
-            if (checkBrackets(arguments.optString(2))) {
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
             }
 
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -238,10 +255,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             if (
-                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
-                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
-                    && maxRange == -1
-                    && range == -1
+                    APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                            && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                            && maxRange == -1
+                            && range == -1
             ) {
                 ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
                 return MethodResult.of(true);
@@ -259,19 +276,42 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
+
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
             ResourceKey<Level> dimension = getLevel().dimension();
-            if (checkBrackets(arguments.optString(2))) {
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
             }
 
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -281,10 +321,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             if (
-                APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
-                    && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
-                    && maxRange == -1
-                    && range == -1
+                    APConfig.PERIPHERALS_CONFIG.chatBoxBroadcast.get()
+                            && APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get()
+                            && maxRange == -1
+                            && range == -1
             ) {
                 ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastSystemMessage(preparedMessage, false);
                 return MethodResult.of(true);
@@ -302,10 +342,17 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 color, 5 range
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(5, -1);
@@ -324,14 +371,30 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "illegal message");
             }
 
-            if (checkBrackets(arguments.optString(3))) {
+            Optional<String> brackets = arguments.optString(3);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
             }
 
+            Optional<String> prefix = arguments.optString(2);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -349,11 +412,18 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
     }
 
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
             String title = arguments.getString(1);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+                title = StringUtil.byteStringToUTF8(title);
+            }
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -381,14 +451,32 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "illegal title");
             }
 
-            if (checkBrackets(arguments.optString(4))) {
+            Optional<String> brackets = arguments.optString(4);
+
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ,,,)");
             }
 
+
+            Optional<String> prefix = arguments.optString(3);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -408,10 +496,16 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 bracket color, 5 range, 6 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(6, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(5, -1);
@@ -421,14 +515,30 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "incorrect player name/uuid");
             }
 
-            if (checkBrackets(arguments.optString(3))) {
+            Optional<String> brackets = arguments.optString(3);
+
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
             }
 
+            Optional<String> prefix = arguments.optString(2);
+
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -445,11 +555,20 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8compatible
     @LuaFunction(mainThread = true)
     public final MethodResult sendToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
             String title = arguments.getString(1);
+
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+                title = StringUtil.byteStringToUTF8(title);
+            }
+
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -459,14 +578,31 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
                 return MethodResult.of(null, "incorrect player name/uuid");
             }
 
-            if (checkBrackets(arguments.optString(4))) {
+            Optional<String> brackets = arguments.optString(4);
+
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets)) {
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
             }
 
+            Optional<String> prefix = arguments.optString(3);
+
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElseGet(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix)),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             );
             if (preparedMessage == null) {
                 return MethodResult.of(null, "illegal prefix");
@@ -487,8 +623,10 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public void update() {
         lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> {
+            String byteString = StringUtil.utf8ToByteString(message.message());
             for (IComputerAccess computer : getConnectedComputers()) {
-                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden());
+                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(),
+                        byteString);
             }
         });
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
@@ -1,5 +1,7 @@
 package de.srendi.advancedperipherals.common.util;
 
+import java.nio.charset.StandardCharsets;
+
 public class StringUtil {
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
@@ -30,5 +32,34 @@ public class StringUtil {
      */
     public static String convertAndToSectionMark(String str) {
         return str == null ? null : str.replaceAll("(?<!\\\\)&(?=[0-9a-z])", "\u00a7").replaceAll("\\\\&", "&");
+    }
+
+    /**
+     * Converts from a lua-sourced byte string to a UTF-8 string.
+     * </p>
+     * Lua encodes bytes as 8bit ASCII (latin1) strings.
+     * To convert this to a UTF-8 string, we need to interpret the byte string as ISO-8859-1 to get each individual byte,
+     * then convert that to a UTF-8 string.
+     *
+     *
+     * @param asciiByteString the utf encoded string sourced from lua.
+     * @return A String, with all characters correctly interpreted as UTF-8.
+     */
+    public static String byteStringToUTF8(String asciiByteString) {
+        return new String(asciiByteString.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Converts from a UTF-8 string to a lua-sourced byte string.
+     * </p>
+     * Lua enforces that all characters in any string passed to it are valid latin1 characters (0-255)
+     * </p>
+     * to get around this, we first convert the UTF-8 string to bytes, which are interpreted as characters seperately.
+     *
+     * @param utf8String the utf encoded string sourced from lua.
+     * @return a string, with all multibyte sequence characters split into their individual byte characters.
+     */
+    public static String utf8ToByteString(String utf8String) {
+        return new String(utf8String.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
     }
 }


### PR DESCRIPTION
Backports #757 to 1.19.2

adds optional "useUtf8" parameter, informing us that the program is utf8 aware, providing its strings as utf8,
This allows sending messages in the extended minecraft character set.

see the utf8 lib in cc, as well as the \u{xxxx} escape sequence.

also sends the events with a new utf8 message parameter.