### PR TITLE
Fixed bug that ME Bridge could void chemicals during exporting/importing

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/MEChemicalHandler.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/MEChemicalHandler.java
@@ -51,7 +51,7 @@ public class MEChemicalHandler implements IStorageSystemChemicalHandler {
 
         ChemicalStack extracted = chemicalKey.getRight().getStack();
 
-        long amountExtracted = storageMonitor.extract(chemicalKey.getRight(), filter.getCount(), simulate == Action.SIMULATE ? Actionable.SIMULATE : Actionable.MODULATE, actionSource);
+        long amountExtracted = storageMonitor.extract(chemicalKey.getRight(), count, simulate == Action.SIMULATE ? Actionable.SIMULATE : Actionable.MODULATE, actionSource);
         extracted.setAmount(amountExtracted);
         AdvancedPeripherals.debug("Extracted chemical: " + extracted + " from filter: " + filter);
         return extracted;

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
@@ -33,29 +33,54 @@ public class ChemicalUtil {
         // The logic changes with storage systems since these systems do not have slots
         if (inventoryFrom instanceof IStorageSystemChemicalHandler storageSystemHandler) {
             ChemicalStack extracted = storageSystemHandler.extractChemical(filter, amount, Action.SIMULATE);
-            ChemicalStack remaining = inventoryTo.insertChemical(extracted, Action.EXECUTE);
-
-            transferableAmount += storageSystemHandler.extractChemical(filter, amount - remaining.getAmount(), Action.EXECUTE).getAmount();
-
+            amount = Math.min(amount, extracted.getAmount());
+            if (amount > 0) {
+                ChemicalStack remaining;
+                int toSlot = filter.getToSlot();
+                if (toSlot >= 0) {
+                    remaining = inventoryTo.insertChemical(toSlot, extracted, Action.EXECUTE);
+                } else {
+                    remaining = inventoryTo.insertChemical(extracted, Action.EXECUTE);
+                }
+                amount -= remaining.getAmount();
+            }
+            if (amount > 0) {
+                transferableAmount += storageSystemHandler.extractChemical(filter, amount, Action.EXECUTE).getAmount();
+            }
             return transferableAmount;
         }
 
         if (inventoryTo instanceof IStorageSystemChemicalHandler storageSystemHandler) {
-            if (filter.test(inventoryFrom.getChemicalInTank(0))) {
-                ChemicalStack toExtract = inventoryFrom.getChemicalInTank(0).copy();
-                toExtract.setAmount(amount);
-                ChemicalStack extracted = inventoryFrom.extractChemical(toExtract, Action.SIMULATE);
-                if (extracted.isEmpty())
-                    return 0;
-                long remaining = storageSystemHandler.insertChemical(extracted, Action.EXECUTE).getAmount();
-
-                extracted.setAmount(extracted.getAmount() + remaining);
-                transferableAmount += inventoryFrom.extractChemical(extracted, Action.EXECUTE).getAmount();
+            int fromSlot = filter.getFromSlot();
+            if (fromSlot >= 0) {
+                transferableAmount = importChemical(inventoryFrom, filter, storageSystemHandler, amount, fromSlot);
+            } else {
+                int tanks = inventoryFrom.getChemicalTanks();
+                for (int i = 0; amount > 0 && i < tanks; i++) {
+                    long imported = importChemical(inventoryFrom, filter, storageSystemHandler, amount, i);
+                    transferableAmount += imported;
+                    amount -= imported;
+                }
             }
-
             return transferableAmount;
         }
 
+        return transferableAmount;
+    }
+
+    private static long importChemical(IChemicalHandler inventoryFrom, ChemicalFilter filter, IStorageSystemChemicalHandler storageSystemHandler, long amount, int tank) {
+        long transferableAmount = 0;
+        ChemicalStack chemicalInTank = inventoryFrom.getChemicalInTank(tank);
+        if (filter.test(chemicalInTank)) {
+            ChemicalStack extracted = inventoryFrom.extractChemical(tank, amount, Action.SIMULATE);
+            if (!extracted.isEmpty()) {
+                long remaining = storageSystemHandler.insertChemical(extracted, Action.EXECUTE).getAmount();
+                long extracting = extracted.getAmount() - remaining;
+                if (extracting > 0) {
+                    transferableAmount += inventoryFrom.extractChemical(tank, extracting, Action.EXECUTE).getAmount();
+                }
+            }
+        }
         return transferableAmount;
     }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

  - `MEBridgePeripheral.exportChemical` voids chemicals when the target peripheral couldn't fit all the amount extracted from the ME Network.
    - And it doesn't respect `filter.toSlot`.
  - `MEBridgePeripheral.importChemical` voids chemicals when the ME Network couldn't fit all the amount extracted from the target peripheral.
    - And it doesn't respect `filter.fromSlot` either.

Voiding chemicals causes some ethical issues around Nuclear Wastes similar to [this](https://github.com/AppliedEnergistics/Applied-Mekanistics/issues/61).

* **What is the new behavior (if this is a feature change)?**

  - `MEBridgePeripheral.exportChemical` no longer voids chemicals when the target peripheral couldn't fit all the amount extracted from the ME Network.  
    - And it now also respects `filter.toSlot`.
  - `MEBridgePeripheral.importChemical` no longer voids chemicals when the ME Network couldn't fit all the amount extracted from the target peripheral.  
    - And it now also respects `filter.fromSlot`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
Yes (Nuclear Wastes can no longer be destroyed in this way)

* **Other information**: