### PR TITLE
Fix: When installing this mod in the ATM10 V6.0 modpack, executing 's…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,93 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Client",
+      "presentation": {
+        "group": "Mod Development - AdvancedPeripherals",
+        "order": 0
+      },
+      "projectName": "AdvancedPeripherals",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003dadvancedperipherals%%E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Data",
+      "presentation": {
+        "group": "Mod Development - AdvancedPeripherals",
+        "order": 1
+      },
+      "projectName": "AdvancedPeripherals",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\dataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\dataRunVmArgs.txt",
+        "-Dfml.modFolders\u003dadvancedperipherals%%E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "GameTestServer",
+      "presentation": {
+        "group": "Mod Development - AdvancedPeripherals",
+        "order": 2
+      },
+      "projectName": "AdvancedPeripherals",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\gameTestServerRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\gameTestServerRunVmArgs.txt",
+        "-Dfml.modFolders\u003dadvancedperipherals%%E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Server",
+      "presentation": {
+        "group": "Mod Development - AdvancedPeripherals",
+        "order": 3
+      },
+      "projectName": "AdvancedPeripherals",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\build\\moddev\\serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003dadvancedperipherals%%E:\\Project_All\\Trae\\Advancedperipherals\\AdvancedPeripherals\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    }
+  ]
+}

--- a/src/main/java/de/srendi/advancedperipherals/common/events/Events.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/events/Events.java
@@ -71,7 +71,30 @@ public class Events {
             return;
         String username = "sayCommand";
         String uuid = null;
-        String message = MessageArgument.getMessage(event.getParseResults().getContext().build("apChatEvent"), "message").getString();
+        /*
+        - 修复：在ATM10 V6.0整合包中安装该模组，当服务端后台cmd发送say且不带有参数即仅发送say时触发服务器崩溃
+        - MessageArgument.getMessage() 方法在参数不存在时会抛出 IllegalArgumentException
+        - 代码没有处理这种异常情况
+        - 貌似是这样(: (可能有误)
+
+        - Fix: When installing this mod in the ATM10 V6.0 modpack, executing 'say' from the server backend CMD without any parameters (i.e., just 'say') triggers a server crash
+        - MessageArgument.getMessage() throws IllegalArgumentException when the parameter does not exist
+        - The code does not handle this exception
+        - That seems to be the case (: (might be inaccurate)
+        */
+        //↓================================修改点Refactoring====================================================↓
+        //并不是专业的程序员，因此修改仅供参考
+        //I'm not a professional programmer, so the modifications I make are for reference only.
+        //Previous: String message = MessageArgument.getMessage(event.getParseResults().getContext().build("apChatEvent"), "message").getString();
+        String message;
+        try {
+            message = MessageArgument.getMessage(event.getParseResults().getContext().build("apChatEvent"), "message").getString();
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        //↑===============================修改点Refactoring====================================================↑
+
+
         boolean isHidden = false;
         CommandSourceStack source = event.getParseResults().getContext().getSource();
         if (source.getEntity() != null) {


### PR DESCRIPTION
* **请检查此 PR 是否符合以下要求 (Please check if the PR fulfills these requirements)**
- [x] 提交信息描述清晰 (The commit message are well described)
- [] 文档已添加/更新 (Docs have been added / updated)
- [x] 所有修改均已充分测试 (All changes have fully been tested)

* **此 PR 引入的变更类型 (What kind of change does this PR introduce?)**
Bug 修复 (Bug fix)

* **当前行为是什么？(What is the current behavior?)**
在 ATM10 V6.0 整合包中，当服务器后台 cmd 发送 say 且不带有参数（即仅发送 say）时触发服务器崩溃
When installing this mod in the ATM10 V6.0 modpack, executing 'say' from the server backend CMD without any parameters (i.e., just 'say') triggers a server crash

问题代码在 Events.java
The issue occurs in Events.java

根本原因：
Root cause:
MessageArgument.getMessage() 方法在参数不存在时会抛出 IllegalArgumentException
MessageArgument.getMessage() throws IllegalArgumentException when the parameter does not exist

旧代码没有处理这种异常情况
The previous code did not handle this exception

* **修复后的新行为是什么？(What is the new behavior?)**
添加了异常捕获，当参数不存在时不会导致服务器崩溃
Added exception handling to prevent server crash when the parameter does not exist

* **此 PR 是否引入破坏性变更？(Does this PR introduce a breaking change?)**
否
No

* **其他信息 (Other information)**
无
No
