### PR TITLE
Fix AE2 Things mod ID

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/APAddon.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/APAddon.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 public enum APAddon {
 
     AE2("ae2"),
-    AE2_THINGS("ae2_things"),
+    AE2_THINGS("ae2things"),
     APP_MEKANISTICS("appmek"),
     CURIOS("curios"),
     MEKANISM("mekanism"),


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/dev/1.21.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**


* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
This PR fixes the mod ID of AE2 Things, it's `ae2things` not `ae2_things`. Ref: https://github.com/Technici4n/AE2Things-Forge/blob/4f2503cca033526a1299c800878360994d3649f1/src/main/java/io/github/projectet/ae2things/AE2Things.java#L38.

* **What is the current behavior?** (You can also link to an open issue here)
Currently if we have a 256k item cell from AE2 Things, it won't be shown in `getCells` call, due to the `APAddon.AE2_THINGS.isLoaded()` returns false even though it's loaded ([ref](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/94850d8ad2416d39084dc1293f7ad9704bdb4081/src/main/java/de/srendi/advancedperipherals/common/addons/appliedenergistics/AEApi.java#L964)).

* **What is the new behavior (if this is a feature change)?**
It will be correctly shown.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No.
