### PR TITLE
Backport Chat Box UTF-8 support to 1.20.1

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/peripheral/ChatBoxPeripheral.java
@@ -106,10 +106,17 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         return brackets.isPresent() && brackets.get().length() != 2;
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
@@ -117,13 +124,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (component == null)
                 return MethodResult.of(null, "incorrect json");
 
-            if (checkBrackets(arguments.optString(2)))
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(component);
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -135,20 +157,43 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 prefix, 2 brackets, 3 color, 4 range, 5 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessage(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(5, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(4, -1);
             ResourceKey<Level> dimension = getLevel().dimension();
-            if (checkBrackets(arguments.optString(2)))
+
+            Optional<String> brackets = arguments.optString(2);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(1);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(3, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(1, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(2, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
             for (ServerPlayer player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
                 if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -160,10 +205,17 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 color, 5 range, 6 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(6, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(5, -1);
@@ -176,13 +228,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (component == null)
                 return MethodResult.of(null, "incorrect json");
 
-            if (checkBrackets(arguments.optString(3)))
+            Optional<String> brackets = arguments.optString(3);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(2);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(component);
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
@@ -194,11 +261,22 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
     }
 
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendFormattedToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String title = arguments.getString(1);
+            if (useUTF8) {
+                title = StringUtil.byteStringToUTF8(title);
+            }
+
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -215,13 +293,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (titleComponent == null)
                 return MethodResult.of(null, "incorrect json for title");
 
-            if (checkBrackets(arguments.optString(4)))
+            Optional<String> brackets = arguments.optString(4);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ,,,)");
 
+            Optional<String> prefix = arguments.optString(3);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(messageComponent);
 
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -236,10 +329,17 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 playerName, 2 prefix, 3 brackets, 4 bracket color, 5 range, 6 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendMessageToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(6, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String playerName = arguments.getString(1);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(5, -1);
@@ -248,13 +348,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-            if (checkBrackets(arguments.optString(3)))
+            Optional<String> brackets = arguments.optString(3);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(2);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(4, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(2, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(3, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(4, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
                 return MethodResult.of(false, "NOT_SAME_DIMENSION");
@@ -265,11 +380,22 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
         });
     }
 
+    // 0 message, 1 title, 2 playerName, 3 prefix, 4 brackets, 5 bracket color, 6 range, 7 utf8Support
     @LuaFunction(mainThread = true)
     public final MethodResult sendToastToPlayer(@NotNull IArguments arguments) throws LuaException {
         return withChatOperation(ignored -> {
+            boolean useUTF8 = arguments.optBoolean(7, false);
+
             String message = arguments.getString(0);
+            if (useUTF8) {
+                message = StringUtil.byteStringToUTF8(message);
+            }
+
             String title = arguments.getString(1);
+            if (useUTF8) {
+                title = StringUtil.byteStringToUTF8(title);
+            }
+
             String playerName = arguments.getString(2);
             int maxRange = APConfig.PERIPHERALS_CONFIG.chatBoxMaxRange.get();
             int range = arguments.optInt(6, -1);
@@ -278,13 +404,28 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
             if (player == null)
                 return MethodResult.of(null, "incorrect player name/uuid");
 
-            if (checkBrackets(arguments.optString(4)))
+            Optional<String> brackets = arguments.optString(4);
+            if (useUTF8) {
+                brackets = brackets.map(StringUtil::byteStringToUTF8);
+            }
+
+            if (checkBrackets(brackets))
                 return MethodResult.of(null, "incorrect bracket string (e.g. [], {}, <>, ...)");
 
+            Optional<String> prefix = arguments.optString(3);
+            if (useUTF8) {
+                prefix = prefix.map(StringUtil::byteStringToUTF8);
+            }
+
+            String bracketColor = arguments.optString(5, "");
+            if (useUTF8) {
+                bracketColor = StringUtil.byteStringToUTF8(bracketColor);
+            }
+
             MutableComponent preparedMessage = appendPrefix(
-                    StringUtil.convertAndToSectionMark(arguments.optString(3, APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
-                    arguments.optString(4, "[]"),
-                    StringUtil.convertAndToSectionMark(arguments.optString(5, ""))
+                    StringUtil.convertAndToSectionMark(prefix.orElse(APConfig.PERIPHERALS_CONFIG.defaultChatBoxPrefix.get())),
+                    brackets.orElse("[]"),
+                    StringUtil.convertAndToSectionMark(bracketColor)
             ).append(message);
 
             if (!APConfig.PERIPHERALS_CONFIG.chatBoxMultiDimensional.get() && player.level().dimension() != dimension)
@@ -300,9 +441,11 @@ public class ChatBoxPeripheral extends BasePeripheral<IPeripheralOwner> {
 
     public void update() {
         lastConsumedMessage = Events.traverseChatMessages(lastConsumedMessage, message -> {
+            String messageUtf8 = StringUtil.utf8ToByteString(message.message());
             for (IComputerAccess computer : getConnectedComputers()) {
-                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden());
+                computer.queueEvent("chat", message.username(), message.message(), message.uuid(), message.isHidden(), messageUtf8);
             }
         });
+
     }
 }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
@@ -33,10 +33,30 @@ public class StringUtil {
         return str == null ? null : str.replaceAll("(?<!\\\\)&(?=[0-9a-z])", "\u00a7").replaceAll("\\\\&", "&");
     }
 
+    /**
+     * Converts from a lua-sourced byte string to a UTF-8 string.
+     * </p>
+     * Lua encodes bytes as 8bit ASCII (latin1) strings.
+     * To convert this to a UTF-8 string, we need to interpret the byte string as ISO-8859-1 to get each individual byte,
+     * then convert that to a UTF-8 string.
+     *
+     * @param asciiByteString the utf encoded string sourced from lua.
+     * @return A String, with all characters correctly interpreted as UTF-8.
+     */
     public static String byteStringToUTF8(String asciiByteString) {
         return new String(asciiByteString.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
     }
 
+    /**
+     * Converts from a UTF-8 string to a lua-sourced byte string.
+     * </p>
+     * Lua enforces that all characters in any string passed to it are valid latin1 characters (0-255)
+     * </p>
+     * to get around this, we first convert the UTF-8 string to bytes, which are interpreted as characters separately.
+     *
+     * @param utf8String the utf encoded string sourced from lua.
+     * @return a string, with all multibyte sequence characters split into their individual byte characters.
+     */
     public static String utf8ToByteString(String utf8String) {
         return new String(utf8String.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/StringUtil.java
@@ -1,4 +1,5 @@
 package de.srendi.advancedperipherals.common.util;
+import java.nio.charset.StandardCharsets;
 
 public class StringUtil {
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
@@ -30,5 +31,13 @@ public class StringUtil {
      */
     public static String convertAndToSectionMark(String str) {
         return str == null ? null : str.replaceAll("(?<!\\\\)&(?=[0-9a-z])", "\u00a7").replaceAll("\\\\&", "&");
+    }
+
+    public static String byteStringToUTF8(String asciiByteString) {
+        return new String(asciiByteString.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+    }
+
+    public static String utf8ToByteString(String utf8String) {
+        return new String(utf8String.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
     }
 }


### PR DESCRIPTION
**PLEASE READ THE [GUIDELINES](https://github.com/IntelligenceModding/AdvancedPeripherals/blob/dev/1.21.1/CONTRIBUTING.md) BEFORE MAKING A CONTRIBUTION**

* **Please check if the PR fulfills these requirements**
- [x] The commit message are well described
- [x] All changes have fully been tested

* **What kind of change does this PR introduce?** (Bug fix, feature, ...)
Backport / compatibility improvement for Chat Box UTF-8 support on `1.20.1`.

* **What is the current behavior?** (You can also link to an open issue here)
On `1.20.1`, Chat Box UTF-8 behavior is incomplete compared to the already documented API.
Messages containing non-ASCII characters may be lost or degraded when sent from Lua, and incoming `chat` events do not expose a UTF-8-safe message payload for scripts.

* **What is the new behavior (if this is a feature change)?**
This PR backports the Chat Box UTF-8 behavior from `1.21.1` to `1.20.1`.

It adds support for the optional trailing `utf8Support` argument to:
- `sendMessage`
- `sendMessageToPlayer`
- `sendToastToPlayer`
- `sendFormattedMessage`
- `sendFormattedMessageToPlayer`
- `sendFormattedToastToPlayer`

It also extends the emitted `chat` event with:
- `messageUtf8` as the 5th payload value

This keeps old scripts compatible while allowing new scripts to safely work with UTF-8 text.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their scripts due to this PR?)
No.

This PR is intentionally backward compatible:
- existing method names are unchanged
- existing argument order is unchanged
- `utf8Support` is optional and only added as the final argument
- existing `chat` event fields are preserved

Old scripts should continue to work unchanged.
Scripts that want UTF-8-safe input can start reading the new `messageUtf8` event value.

* **Other information**:
Tested on `1.20.1` with:
- `sendMessage`
- `sendMessageToPlayer`
- `sendToastToPlayer`
- `sendFormattedMessage`
- `sendFormattedMessageToPlayer`
- `sendFormattedToastToPlayer`

Observed behavior:
- all tested methods returned success
- UTF-8 output rendered correctly in chat and toasts
- incoming `chat` events exposed readable UTF-8 text through `messageUtf8`
- legacy `message` field remained unchanged for backward compatibility

This is a focused backport of Chat Box UTF-8 behavior only and does not attempt to backport unrelated `1.21.1` changes.